### PR TITLE
handle more types of outputs

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -14,6 +14,7 @@ import pandas as pd  # type: ignore
 # technically dataframe labels can be all sorts of things...
 # TODO: handle other index dtypes
 Label = t.Union[int, str]
+Labels = t.Union[t.List[int], t.List[str]]
 
 
 def _diagram_as_dict(dclass):
@@ -107,15 +108,15 @@ class DataPair:
 @dataclasses.dataclass
 class DFSpec:
     type: str = dataclasses.field(default='DataFrame', init=False, repr=False)
-    col_names: t.List[Label]
-    row_labels: t.List[Label]
+    col_names: Labels
+    row_labels: Labels
     data: t.List[t.List]
 
 
 @dataclasses.dataclass
 class SeriesSpec:
     type: str = dataclasses.field(default='Series', init=False, repr=False)
-    row_labels: t.List[Label]
+    row_labels: Labels
     data: t.List
 
 
@@ -130,7 +131,7 @@ class GroupBySpec(DFSpec):
 @dataclasses.dataclass
 class GroupData:
     # grouping cols, if we can pull them out
-    col_names: t.List[Label]
+    col_names: Labels
 
     # info about each group, like the attributes
     groups: t.List[Group]
@@ -144,10 +145,17 @@ class Group:
     # then the group names will be: ('small', 'low'), ('small', 'high'), ...
     #
     # the labels appear in the same order as GroupData.col_names
-    name: t.List[Label]
+    name: list
 
     # labels for all rows the group contains
-    labels: t.List[Label]
+    labels: Labels
 
 
-DataSpec = t.Union[DFSpec, SeriesSpec, GroupBySpec]
+@dataclasses.dataclass
+class UnhandledData:
+    '''catch-all for data that we don't know how to handle, like scalars'''
+    type: str = dataclasses.field(default='Unhandled', init=False, repr=False)
+    data: t.Any
+
+
+DataSpec = t.Union[DFSpec, SeriesSpec, GroupBySpec, UnhandledData]

--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -52,7 +52,10 @@ class Diagram:
     type: str
     code_step: str
     mapping: t.List[Mark]
-    data_frame: DFPair
+
+    # although we call this data_frame, technically it can hold any type of
+    # data, like series or groupbys
+    data_frame: DataPair
 
     def to_dict(self):
         return dataclasses.asdict(self, dict_factory=_diagram_as_dict)
@@ -96,16 +99,55 @@ class TablePos:
 
 
 @dataclasses.dataclass
-class DFPair:
-    lhs: DFSpec
-    rhs: DFSpec
+class DataPair:
+    lhs: DataSpec
+    rhs: DataSpec
 
 
 @dataclasses.dataclass
 class DFSpec:
-    col_names: t.List[str]
-    row_labels: t.List[str]
+    type: str = dataclasses.field(default='DataFrame', init=False, repr=False)
+    col_names: t.List[Label]
+    row_labels: t.List[Label]
     data: t.List[t.List]
 
-    # For groupby objects, holds the group info
-    groups: t.Optional[dict] = None
+
+@dataclasses.dataclass
+class SeriesSpec:
+    type: str = dataclasses.field(default='Series', init=False, repr=False)
+    row_labels: t.List[Label]
+    data: t.List
+
+
+@dataclasses.dataclass
+class GroupBySpec(DFSpec):
+    type: str = dataclasses.field(default='DataFrameGroupBy',
+                                  init=False,
+                                  repr=False)
+    group_data: GroupData
+
+
+@dataclasses.dataclass
+class GroupData:
+    # grouping cols, if we can pull them out
+    col_names: t.List[Label]
+
+    # info about each group, like the attributes
+    groups: t.List[Group]
+
+
+@dataclasses.dataclass
+class Group:
+    '''a group maps between dataframe values -> labels that match'''
+    # the group name is the unique combo of grouping vals, so if we do:
+    # >>> dogs.groupby(['size', 'kids'])
+    # then the group names will be: ('small', 'low'), ('small', 'high'), ...
+    #
+    # the labels appear in the same order as GroupData.col_names
+    name: t.List[Label]
+
+    # labels for all rows the group contains
+    labels: t.List[Label]
+
+
+DataSpec = t.Union[DFSpec, SeriesSpec, GroupBySpec]

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -13,7 +13,7 @@ from .parse_nodes import (AggCall, Axis, ChainStep, GroupByCall, HeadCall,
 from .run import DFResult, EvalResult, GroupbyResult, UnhandledResult
 
 
-# yes, step comes from after.step, but we pull it out here to help with
+# step comes from after.step, but we pull it out here to help with
 # the type checker
 def make_marks(step: ChainStep, before: EvalResult,
                after: EvalResult) -> t.List[Mark]:

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -10,7 +10,7 @@ from .diagram import Highlight, Mark, Outline, Selection, TablePos
 from .parse_nodes import (AggCall, Axis, ChainStep, GroupByCall, HeadCall,
                           PassThroughCall, RenameCall, SortValuesCall,
                           SubsComparison, Subscript, TailCall)
-from .run import DFResult, EvalResult, GroupbyResult, UnhandledResult
+from .run import DFResult, EvalResult, GroupbyResult, SeriesResult
 
 
 # step comes from after.step, but we pull it out here to help with
@@ -135,22 +135,21 @@ def mark_for_agg(step: AggCall, before: EvalResult,
 # df.groupby('Sex')[['Count']]
 def mark_for_subscript(step: Subscript, before: EvalResult,
                        after: EvalResult) -> t.List[Mark]:
-    before_df: pd.DataFrame
-    after_df: pd.DataFrame
-
-    if (isinstance(before, GroupbyResult)
-            and isinstance(after, GroupbyResult)):
-        before_df = util.ungroup(before.val)
-        after_df = util.ungroup(after.val)
-    elif not (isinstance(before, DFResult) and isinstance(after, DFResult)):
+    if (isinstance(before, DFResult) and isinstance(after, SeriesResult)):
+        return mark_for_subscript_to_series(step, before, after)
+    elif not isinstance(before, (DFResult, GroupbyResult)):
         return []
-    else:
-        before_df = before.val
-        after_df = after.val
+    elif not isinstance(after, (DFResult, GroupbyResult)):
+        return []
 
     row_slice = step.slice1
     col_slice = step.slice2
     args = after.args
+
+    before_df = util.ungroup(before.val) if isinstance(
+        before, GroupbyResult) else before.val
+    after_df = util.ungroup(after.val) if isinstance(
+        after, GroupbyResult) else after.val
     row_marks = diff_rows(before_df, after_df)
     col_marks = diff_cols(before_df, after_df)
 
@@ -167,6 +166,31 @@ def mark_for_subscript(step: Subscript, before: EvalResult,
     return [*col_marks, *row_marks]
 
 
+def mark_for_subscript_to_series(step: Subscript, before: EvalResult,
+                                 after: EvalResult) -> t.List[Mark]:
+    args = after.args
+    # when the output is a series, just highlight the row/column used for
+    # slicing, like the 'kids' in df['kids']
+
+    # df['kids']
+    if step.slicer is None:
+        maybe_col = args.get('slice1_values')
+        if isinstance(maybe_col, (str, int)):
+            return make_highlights([maybe_col], 'column')
+    else:
+        # df.iloc[0]
+        maybe_row = args.get('slice1_values')
+        if isinstance(maybe_row, (str, int)):
+            return make_highlights([maybe_row], 'row')
+
+        # df.iloc[:, 0]
+        maybe_col = args.get('slice2_values')
+        if isinstance(maybe_col, (str, int)):
+            return make_highlights([maybe_col], 'column')
+
+    return []
+
+
 def diff_dfs(df1: pd.DataFrame, df2: pd.DataFrame):
     '''
     when we just want to draw arrows between different rows and cols without
@@ -178,7 +202,7 @@ def diff_dfs(df1: pd.DataFrame, df2: pd.DataFrame):
     return [*cols, *rows]
 
 
-def diff_rows(df1: pd.DataFrame, df2: pd.DataFrame):
+def diff_rows(df1: util.HasIndex, df2: util.HasIndex):
     '''
     when we just want to draw arrows between different rows and cols without
     special highlights. only outputs when there is at least one mismatching row

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -69,7 +69,8 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
 
     eval_results = []
     for step in last_expr.chain:
-        # wrap individual steps in parens before eval since they can have newlines
+        # wrap individual steps in parens before eval since subexpressions
+        # within a line can have newlines
         val = eval(f"({step.code})", user_globals)
         args = eval_args(step, user_globals)
         result = make_result(step, val, args)
@@ -81,8 +82,10 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
 def make_result(step: ChainStep, val: t.Any, args: Args) -> EvalResult:
     if isinstance(val, util.DataFrameGroupBy):
         return GroupbyResult(step, args, val)
-    if isinstance(val, pd.DataFrame):
+    elif isinstance(val, pd.DataFrame):
         return DFResult(step, args, val)
+    elif isinstance(val, pd.Series):
+        return SeriesResult(step, args, val)
     else:
         return UnhandledResult(step, args, val)
 

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -34,6 +34,11 @@ class DFResult(EvalBase):
 
 
 @dataclasses.dataclass
+class SeriesResult(EvalBase):
+    val: pd.Series
+
+
+@dataclasses.dataclass
 class GroupbyResult(EvalBase):
     val: util.DataFrameGroupBy
 
@@ -44,7 +49,7 @@ class UnhandledResult(EvalBase):
     val: t.Any
 
 
-EvalResult = t.Union[DFResult, GroupbyResult, UnhandledResult]
+EvalResult = t.Union[DFResult, SeriesResult, GroupbyResult, UnhandledResult]
 
 
 # TODO: handle stdout and stderr from user code

--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -9,7 +9,7 @@ import typing as t
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .diagram import DFPair, DFSpec, Diagram
+from .diagram import DataPair, DFSpec, Diagram, Group, GroupBySpec, GroupData
 from .marks import make_marks
 from .run import DFResult, EvalResult, GroupbyResult
 from . import util
@@ -35,7 +35,7 @@ def serialize_one_step(before: EvalResult, after: EvalResult) -> Diagram:
 
     # this serializes every df twice when we should only do it once.
     # TODO: optimize this
-    df_pair = DFPair(
+    df_pair = DataPair(
         lhs=serialize_step_val(before),
         rhs=serialize_step_val(after),
     )
@@ -72,19 +72,26 @@ def serialize_step_val(step: EvalResult) -> DFSpec:
                   data=df.to_numpy().tolist())  # type: ignore
 
 
-def serialize_groupby(val: util.DataFrameGroupBy) -> DFSpec:
-    # val.groups is {group: labels}, but group can be a tuple (when grouping on
-    # multiple cols), and labels is a pandas index
-    groups = {
-        str(k): v.tolist()  # type: ignore
-        for k, v in val.groups.items()
-    }
+def serialize_groupby(val: util.DataFrameGroupBy) -> GroupBySpec:
+    # NOTE: when grouping by unnamed sequences, names will contain None
+    # >>> full.groupby([test, test2]).grouper.names
+    # [None, None]
+    col_names = val.grouper.names
+
+    df_groups = t.cast(util.Groups, val.groups)
+    groups = [
+        Group(name=[name] if isinstance(name, str) else list(name),
+              labels=labels.tolist()) for name, labels in df_groups.items()
+    ]
+
     df = util.ungroup(val)
-    return DFSpec(
+
+    group_data = GroupData(col_names=col_names, groups=groups)
+    return GroupBySpec(
         col_names=df.columns.tolist(),
         row_labels=df.index.tolist(),
         data=df.to_numpy().tolist(),  # type: ignore
-        groups=groups)
+        group_data=group_data)
 
 
 def pairs(seq: t.List[T]) -> t.List[t.Tuple[T, T]]:

--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -9,9 +9,9 @@ import typing as t
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .diagram import DataPair, DFSpec, Diagram, Group, GroupBySpec, GroupData
+from .diagram import DataPair, DFSpec, DataSpec, Diagram, Group, GroupBySpec, GroupData, Label, SeriesSpec, UnhandledData
 from .marks import make_marks
-from .run import DFResult, EvalResult, GroupbyResult
+from .run import DFResult, EvalResult, GroupbyResult, SeriesResult
 from . import util
 
 T = t.TypeVar('T')
@@ -46,30 +46,21 @@ def serialize_one_step(before: EvalResult, after: EvalResult) -> Diagram:
                    data_frame=df_pair)
 
 
-def serialize_step_val(step: EvalResult) -> DFSpec:
-    df: pd.DataFrame
+def serialize_step_val(step: EvalResult) -> DataSpec:
     if isinstance(step, DFResult):
         df = step.val
+        return DFSpec(col_names=df.columns.tolist(),
+                      row_labels=df.index.tolist(),
+                      data=df.to_numpy().tolist())
+    elif isinstance(step, SeriesResult):
+        series = step.val
+        return SeriesSpec(row_labels=series.index.tolist(),
+                          data=series.tolist())
     elif isinstance(step, GroupbyResult):
         return serialize_groupby(step.val)
     else:
-        # step.val is unhandled, so we'll do some heuristics
         val = step.val
-        if isinstance(val, str):
-            df = pd.DataFrame([val], columns=['value'])
-        elif isinstance(val, pd.Series):
-            df = val.to_frame()
-        elif isinstance(val, list) or isinstance(val, np.ndarray):
-            df = pd.DataFrame(val, columns=['value'])
-        elif isinstance(val, dict):
-            df = pd.DataFrame(val)
-        else:
-            # fallback: cast to string
-            df = pd.DataFrame(str(val), columns=['value'])
-
-    return DFSpec(col_names=df.columns.tolist(),
-                  row_labels=df.index.tolist(),
-                  data=df.to_numpy().tolist())  # type: ignore
+        return UnhandledData(data=val)
 
 
 def serialize_groupby(val: util.DataFrameGroupBy) -> GroupBySpec:

--- a/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
@@ -36,6 +36,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "a",
           "b",
@@ -66,10 +67,10 @@
             3000,
             4000
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "b",
           "d"
@@ -92,8 +93,7 @@
             2000,
             4000
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -109,10 +110,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -129,8 +130,7 @@
             15581,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -109,10 +110,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -129,8 +130,7 @@
             15581,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
@@ -60,6 +60,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -139,10 +140,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -180,8 +181,7 @@
             15581,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs
+ .groupby('grooming')
+ .max()
+)

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
@@ -1,0 +1,401 @@
+[
+  {
+    "type": "GroupByCall",
+    "code_step": "dogs\n .groupby('grooming')",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "lhs",
+        "label": "grooming",
+        "illustrate": "highlight"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "DataFrameGroupBy",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ],
+        "group_data": {
+          "col_names": [
+            "grooming"
+          ],
+          "groups": [
+            {
+              "name": [
+                "daily"
+              ],
+              "labels": [
+                2,
+                4
+              ]
+            },
+            {
+              "name": [
+                "weekly"
+              ],
+              "labels": [
+                0,
+                1,
+                3,
+                5,
+                6
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "type": "AggCall",
+    "code_step": "(dogs\n .groupby('grooming')\n .max()\n)",
+    "mapping": [
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 2
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "daily"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 4
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "daily"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 0
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "weekly"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 1
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "weekly"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 3
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "weekly"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 5
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "weekly"
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 6
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": "weekly"
+        },
+        "illustrate": "outline"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrameGroupBy",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ],
+        "group_data": {
+          "col_names": [
+            "grooming"
+          ],
+          "groups": [
+            {
+              "name": [
+                "daily"
+              ],
+              "labels": [
+                2,
+                4
+              ]
+            },
+            {
+              "name": [
+                "weekly"
+              ],
+              "labels": [
+                0,
+                1,
+                3,
+                5,
+                6
+              ]
+            }
+          ]
+        }
+      },
+      "rhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          "daily",
+          "weekly"
+        ],
+        "data": [
+          [
+            "Yorkshire Terrier",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Labrador Retriever",
+            466.0,
+            "medium",
+            "medium"
+          ]
+        ]
+      }
+    }
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
@@ -12,6 +12,77 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "DataFrameGroupBy",
         "col_names": [
           "breed",
           "grooming",
@@ -79,79 +150,32 @@
             "medium"
           ]
         ],
-        "groups": null
-      },
-      "rhs": {
-        "col_names": [
-          "breed",
-          "food_cost",
-          "kids",
-          "size"
-        ],
-        "row_labels": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "data": [
-          [
-            "Labrador Retriever",
-            466.0,
-            "high",
-            "medium"
+        "group_data": {
+          "col_names": [
+            "grooming"
           ],
-          [
-            "German Shepherd",
-            466.0,
-            "medium",
-            "large"
-          ],
-          [
-            "Beagle",
-            324.0,
-            "high",
-            "small"
-          ],
-          [
-            "Golden Retriever",
-            466.0,
-            "high",
-            "medium"
-          ],
-          [
-            "Yorkshire Terrier",
-            324.0,
-            "low",
-            "small"
-          ],
-          [
-            "Bulldog",
-            466.0,
-            "medium",
-            "medium"
-          ],
-          [
-            "Boxer",
-            466.0,
-            "high",
-            "medium"
-          ]
-        ],
-        "groups": {
-          "daily": [
-            2,
-            4
-          ],
-          "weekly": [
-            0,
-            1,
-            3,
-            5,
-            6
+          "groups": [
+            {
+              "name": [
+                "daily"
+              ],
+              "labels": [
+                2,
+                4
+              ]
+            },
+            {
+              "name": [
+                "weekly"
+              ],
+              "labels": [
+                0,
+                1,
+                3,
+                5,
+                6
+              ]
+            }
           ]
         }
       }
@@ -248,8 +272,10 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrameGroupBy",
         "col_names": [
           "breed",
+          "grooming",
           "food_cost",
           "kids",
           "size"
@@ -266,62 +292,85 @@
         "data": [
           [
             "Labrador Retriever",
+            "weekly",
             466.0,
             "high",
             "medium"
           ],
           [
             "German Shepherd",
+            "weekly",
             466.0,
             "medium",
             "large"
           ],
           [
             "Beagle",
+            "daily",
             324.0,
             "high",
             "small"
           ],
           [
             "Golden Retriever",
+            "weekly",
             466.0,
             "high",
             "medium"
           ],
           [
             "Yorkshire Terrier",
+            "daily",
             324.0,
             "low",
             "small"
           ],
           [
             "Bulldog",
+            "weekly",
             466.0,
             "medium",
             "medium"
           ],
           [
             "Boxer",
+            "weekly",
             466.0,
             "high",
             "medium"
           ]
         ],
-        "groups": {
-          "daily": [
-            2,
-            4
+        "group_data": {
+          "col_names": [
+            "grooming"
           ],
-          "weekly": [
-            0,
-            1,
-            3,
-            5,
-            6
+          "groups": [
+            {
+              "name": [
+                "daily"
+              ],
+              "labels": [
+                2,
+                4
+              ]
+            },
+            {
+              "name": [
+                "weekly"
+              ],
+              "labels": [
+                0,
+                1,
+                3,
+                5,
+                6
+              ]
+            }
           ]
         }
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "food_cost"
         ],
@@ -336,8 +385,7 @@
           [
             466.0
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/head_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_01.py.golden
@@ -42,6 +42,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -108,10 +109,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -146,8 +147,7 @@
             "high",
             "small"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
@@ -78,6 +78,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -157,10 +158,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Sex",
           "Count",
@@ -187,8 +188,7 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
@@ -42,6 +42,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -121,10 +122,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -155,8 +156,7 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs['breed'])

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
@@ -1,0 +1,107 @@
+[
+  {
+    "type": "Subscript",
+    "code_step": "(dogs['breed'])",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "lhs",
+        "label": "breed",
+        "illustrate": "highlight"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          "Labrador Retriever",
+          "German Shepherd",
+          "Beagle",
+          "Golden Retriever",
+          "Yorkshire Terrier",
+          "Bulldog",
+          "Boxer"
+        ]
+      }
+    }
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs.loc[:, 'food_cost'])

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
@@ -1,0 +1,107 @@
+[
+  {
+    "type": "Subscript",
+    "code_step": "(dogs.loc[:, 'food_cost'])",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "lhs",
+        "label": "food_cost",
+        "illustrate": "highlight"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          466.0,
+          466.0,
+          324.0,
+          466.0,
+          324.0,
+          466.0,
+          466.0
+        ]
+      }
+    }
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
@@ -90,6 +90,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -169,10 +170,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Count"
@@ -205,8 +206,7 @@
             "Emma",
             15581
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -109,10 +110,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Count"
@@ -170,8 +171,7 @@
             "Amelia",
             12704
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
@@ -96,6 +96,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -162,10 +163,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -232,8 +233,7 @@
             "medium",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   },
@@ -316,6 +316,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -382,10 +383,10 @@
             "medium",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -444,8 +445,7 @@
             "medium",
             "large"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
@@ -96,6 +96,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -162,10 +163,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -232,8 +233,7 @@
             "medium",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   },
@@ -292,6 +292,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -358,10 +359,10 @@
             "medium",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -404,8 +405,7 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
@@ -72,6 +72,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "one",
           "two",
@@ -128,10 +129,10 @@
             true,
             null
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "one",
           "two",
@@ -188,8 +189,7 @@
             true,
             "2012-01-01 00:00:00"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -96,10 +97,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "b",
           "grooming",
@@ -166,8 +167,7 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
@@ -5,6 +5,7 @@
     "mapping": [],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -71,10 +72,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "BREED",
           "GROOMING",
@@ -141,8 +142,7 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -96,10 +97,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -166,8 +167,7 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+dogs['food_cost'].mean()

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
@@ -1,0 +1,139 @@
+[
+  {
+    "type": "Subscript",
+    "code_step": "dogs['food_cost']",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "lhs",
+        "label": "food_cost",
+        "illustrate": "highlight"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          466.0,
+          466.0,
+          324.0,
+          466.0,
+          324.0,
+          466.0,
+          466.0
+        ]
+      }
+    }
+  },
+  {
+    "type": "PassThroughCall",
+    "code_step": "dogs['food_cost'].mean()",
+    "mapping": [],
+    "data_frame": {
+      "lhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          466.0,
+          466.0,
+          324.0,
+          466.0,
+          324.0,
+          466.0,
+          466.0
+        ]
+      },
+      "rhs": {
+        "type": "Unhandled",
+        "data": 425.42857142857144
+      }
+    }
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+dogs['breed'].to_frame()

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "Subscript",
+    "code_step": "dogs['breed']",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "lhs",
+        "label": "breed",
+        "illustrate": "highlight"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          "Labrador Retriever",
+          "German Shepherd",
+          "Beagle",
+          "Golden Retriever",
+          "Yorkshire Terrier",
+          "Bulldog",
+          "Boxer"
+        ]
+      }
+    }
+  },
+  {
+    "type": "PassThroughCall",
+    "code_step": "dogs['breed'].to_frame()",
+    "mapping": [],
+    "data_frame": {
+      "lhs": {
+        "type": "Series",
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          "Labrador Retriever",
+          "German Shepherd",
+          "Beagle",
+          "Golden Retriever",
+          "Yorkshire Terrier",
+          "Bulldog",
+          "Boxer"
+        ]
+      },
+      "rhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever"
+          ],
+          [
+            "German Shepherd"
+          ],
+          [
+            "Beagle"
+          ],
+          [
+            "Golden Retriever"
+          ],
+          [
+            "Yorkshire Terrier"
+          ],
+          [
+            "Bulldog"
+          ],
+          [
+            "Boxer"
+          ]
+        ]
+      }
+    }
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
@@ -132,6 +132,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -211,10 +212,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -294,8 +295,7 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
@@ -132,6 +132,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -211,10 +212,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -294,8 +295,7 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
@@ -132,6 +132,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -211,10 +212,10 @@
             12704,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -294,8 +295,7 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   },
@@ -432,6 +432,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -511,10 +512,10 @@
             12541,
             2020
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "Name",
           "Sex",
@@ -594,8 +595,7 @@
             19659,
             2020
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/tests/e2e_golden/tail_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_01.py.golden
@@ -30,6 +30,7 @@
     ],
     "data_frame": {
       "lhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -96,10 +97,10 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       },
       "rhs": {
+        "type": "DataFrame",
         "col_names": [
           "breed",
           "grooming",
@@ -126,8 +127,7 @@
             "high",
             "medium"
           ]
-        ],
-        "groups": null
+        ]
       }
     }
   }

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -6,9 +6,12 @@ import gzip
 import typing as t
 
 import pandas as pd  # type: ignore
-from pandas.core.groupby.generic import DataFrameGroupBy  # type: ignore
+from pandas.core.groupby.generic import (  # type: ignore
+    DataFrameGroupBy, SeriesGroupBy)
 
 from .diagram import Label
+
+HasIndex = t.Union[pd.DataFrame, pd.Series]
 
 Groups = t.Dict[t.Union[str, tuple], pd.Index]
 
@@ -25,9 +28,7 @@ def mapt(fn, *args):
     return tuple(map(fn, *args))
 
 
-def match_rows(df1: pd.DataFrame,
-               df2: pd.DataFrame,
-               only_if_diff=False) -> pd.Index:
+def match_rows(df1: HasIndex, df2: HasIndex, only_if_diff=False) -> pd.Index:
     '''
     find all matching row labels between df1 and df2. if only_if_diff=False
     (default), then return empty list when df1 has exact same rows as df2.
@@ -53,8 +54,19 @@ def match_cols(df1: pd.DataFrame,
             if len(matches) == len(df1.columns) or only_if_diff else matches)
 
 
-def ungroup(groupby: DataFrameGroupBy) -> pd.DataFrame:
-    '''undos a groupby back into original dataframe'''
+@t.overload
+def ungroup(groupby: SeriesGroupBy) -> pd.Series:
+    ...
+
+
+@t.overload
+def ungroup(  # type: ignore # noqa: F811
+        groupby: DataFrameGroupBy) -> pd.DataFrame:
+    ...
+
+
+def ungroup(groupby):  # noqa: F811
+    '''undos a groupby back into original val'''
     # uses a private attribute...hopefully won't break later :)
     return groupby._selected_obj
 

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -55,4 +55,8 @@ def match_cols(df1: pd.DataFrame,
 
 def ungroup(groupby: DataFrameGroupBy) -> pd.DataFrame:
     '''undos a groupby back into original dataframe'''
-    return groupby.transform(lambda x: x)
+    # uses a private attribute...hopefully won't break later :)
+    return groupby._selected_obj
+
+    # slower fallback
+    # return groupby.transform(lambda x: x)


### PR DESCRIPTION
i'm adding an extra `"type"` key to each output so that the frontend can distinguish between dataframes, series, groupbys, and unhandled values (like plain integers).

for instance, dataframes now have:

https://github.com/SamLau95/pandas_tutor/blob/012b17527dbd0821f8f6aa728d20ac3b58c1eae2/pandas_tutor/tests/e2e_golden/head_01.py.golden#L43-L45

here's an example series output:

https://github.com/SamLau95/pandas_tutor/blob/012b17527dbd0821f8f6aa728d20ac3b58c1eae2/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden#L84-L104

series are serialized the same as dataframes except that they don't have column labels, only row labels.

i also updated the groupby spec to better handle multi-index grouping in the future:

https://github.com/SamLau95/pandas_tutor/blob/012b17527dbd0821f8f6aa728d20ac3b58c1eae2/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden#L153-L180

lastly, unhandled values are just serialized to JSON directly.

https://github.com/SamLau95/pandas_tutor/blob/29cf420c55655bc6a47a74e17b1bc3b3febf756a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden#L133-L136