### PR TITLE
handle runtime errors

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -5,6 +5,7 @@ has dataclass definitions for final JSON output.
 from __future__ import annotations
 
 import dataclasses
+from dataclasses import field
 import simplejson as json
 import typing as t
 
@@ -61,13 +62,26 @@ class Diagram:
     def to_dict(self):
         return dataclasses.asdict(self, dict_factory=_diagram_as_dict)
 
+    # a bit clunky since we'll also use this for ErrorOutput, but :shrug:
     @classmethod
-    def to_json(cls, items: t.Union[t.List[Diagram], Diagram]):
+    def to_json(cls, items: t.Any):
         return json.dumps(items,
                           indent=2,
                           default=encode_pd_objs,
                           ignore_nan=True)
 
+
+@dataclasses.dataclass
+class ErrorOutput:
+    type: str = field(default='ErrorOutput', init=False, repr=False)
+    code_step: str
+    message: str
+
+    def to_dict(self):
+        return dataclasses.asdict(self, dict_factory=_diagram_as_dict)
+
+
+Explanation = t.List[t.Union[Diagram, ErrorOutput]]
 
 Selection = t.Literal['column', 'row']
 Anchor = t.Literal['lhs', 'rhs']
@@ -107,7 +121,7 @@ class DataPair:
 
 @dataclasses.dataclass
 class DFSpec:
-    type: str = dataclasses.field(default='DataFrame', init=False, repr=False)
+    type: str = field(default='DataFrame', init=False, repr=False)
     col_names: Labels
     row_labels: Labels
     data: t.List[t.List]
@@ -115,24 +129,20 @@ class DFSpec:
 
 @dataclasses.dataclass
 class SeriesSpec:
-    type: str = dataclasses.field(default='Series', init=False, repr=False)
+    type: str = field(default='Series', init=False, repr=False)
     row_labels: Labels
     data: t.List
 
 
 @dataclasses.dataclass
 class GroupBySpec(DFSpec):
-    type: str = dataclasses.field(default='DataFrameGroupBy',
-                                  init=False,
-                                  repr=False)
+    type: str = field(default='DataFrameGroupBy', init=False, repr=False)
     group_data: GroupData
 
 
 @dataclasses.dataclass
 class SeriesGroupBySpec(SeriesSpec):
-    type: str = dataclasses.field(default='SeriesGroupBy',
-                                  init=False,
-                                  repr=False)
+    type: str = field(default='SeriesGroupBy', init=False, repr=False)
     group_data: GroupData
 
 
@@ -160,7 +170,7 @@ class Group:
 @dataclasses.dataclass
 class UnhandledData:
     '''catch-all for data that we don't know how to handle, like scalars'''
-    type: str = dataclasses.field(default='Unhandled', init=False, repr=False)
+    type: str = field(default='Unhandled', init=False, repr=False)
     data: t.Any
 
 

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -8,8 +8,9 @@ import pandas as pd  # type: ignore
 from . import util
 from .diagram import Highlight, Mark, Outline, Selection, TablePos
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStep,
-                          GroupByCall, HeadCall, PassThroughCall, RenameCall,
-                          SortValuesCall, SubsComparison, Subscript, TailCall)
+                          EvalError, GroupByCall, HeadCall, PassThroughCall,
+                          RenameCall, SortValuesCall, SubsComparison,
+                          Subscript, TailCall)
 from .run import (DFResult, EvalResult, GroupbyResult, SeriesGroupbyResult,
                   SeriesResult)
 
@@ -18,7 +19,11 @@ from .run import (DFResult, EvalResult, GroupbyResult, SeriesGroupbyResult,
 # the type checker
 def make_marks(step: ChainStep, before: EvalResult,
                after: EvalResult) -> t.List[Mark]:
-    if isinstance(step, SortValuesCall):
+    if isinstance(step, EvalError):
+        return no_marks()
+    elif isinstance(step, PassThroughCall):
+        return no_marks()
+    elif isinstance(step, SortValuesCall):
         return mark_for_sort_values(step, before, after)
     elif isinstance(step, RenameCall):
         return mark_for_rename(step, before, after)
@@ -32,17 +37,17 @@ def make_marks(step: ChainStep, before: EvalResult,
         return mark_for_groupby(step, before, after)
     elif isinstance(step, AggCall):
         return mark_for_agg(step, before, after)
-    elif isinstance(step, PassThroughCall):
-        return no_marks(step, before, after)
     elif isinstance(step, Subscript):
         return mark_for_subscript(step, before, after)
     else:
-        return no_marks(step, before, after)
+        return no_marks()
 
 
 # df.sort_values('Name')
 def mark_for_sort_values(step: SortValuesCall, before: EvalResult,
                          after: EvalResult) -> t.List[Mark]:
+    if not (isinstance(before, DFResult) and isinstance(after, DFResult)):
+        return []
     df = before.val
     args = after.args
 

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -285,8 +285,8 @@ class PandasParser(m.MatcherDecoratableVisitor):
     def make_apply(self, cst_node):
         assert self.current is not None, (
             'tried to call make_apply when not in a chain!')
-        # axis only available for dataframes...for series, arg 1 is some other arg
-        # that we don't care about so we should be careful here
+        # axis only available for dataframes...for series, arg 1 is some other
+        # arg that we don't care about so we should be careful here
         axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, 'axis')
         axis = 'index'  # default
         if axis_arg is not None:

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -297,4 +297,23 @@ class SubsEval(Base):
 
 SubscriptEl = t.Union[SubsSlice, SubsComparison, SubsEval]
 
-ChainStep = t.Union[StartOfChain, Call, Subscript]
+##############################################################################
+# Errors
+##############################################################################
+
+_dummy_code_position = CodePosition(-999, -999)
+
+
+@dataclasses.dataclass
+class EvalError(Base):
+    '''represents a step in the chain that caused a runtime error'''
+    # TODO: compute code positions for errors
+    @classmethod
+    def from_code(cls, code: RawCode):
+        return cls(code, start=_dummy_code_position, end=_dummy_code_position)
+
+
+##############################################################################
+# ChainStep
+##############################################################################
+ChainStep = t.Union[StartOfChain, Call, Subscript, EvalError]

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -12,14 +12,19 @@ import typing as t
 
 import pandas as pd  # type: ignore
 
-from .parse_nodes import (AggCall, ChainStatement, ChainStep, ParsedModule,
-                          PassThroughCall, RawCode, Subscript)
 from . import util
+from .parse_nodes import (AggCall, ChainStatement, ChainStep, EvalError,
+                          ParsedModule, PassThroughCall, RawCode, Subscript)
 
 # technically args can be anything...but most of the time it'll be labels
 Arg = t.Union[str, t.List[str]]
 
 Args = t.Dict[str, Arg]
+
+# errors that we care about showing to the user
+serializable_errors = (ArithmeticError, AttributeError, ImportError,
+                       LookupError, NameError, RuntimeError, TypeError,
+                       ValueError)
 
 
 @dataclasses.dataclass
@@ -49,13 +54,18 @@ class SeriesGroupbyResult(EvalBase):
 
 
 @dataclasses.dataclass
+class RuntimeErrorResult(EvalBase):
+    val: Exception
+
+
+@dataclasses.dataclass
 class UnhandledResult(EvalBase):
     '''catch-all for chain outputs we don't know how to serialize'''
     val: t.Any
 
 
 EvalResult = t.Union[UnhandledResult, DFResult, SeriesResult, GroupbyResult,
-                     SeriesGroupbyResult]
+                     SeriesGroupbyResult, RuntimeErrorResult]
 
 
 # TODO: handle stdout and stderr from user code
@@ -64,22 +74,36 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
 
     # hard-code the last one!
     setup_stmts, last_expr = statements[:-1], statements[-1]
-    assert isinstance(last_expr, ChainStatement)
+    if not isinstance(last_expr, ChainStatement):
+        # don't visualize
+        return []
 
     # all the code above the last expression
-    setup_code = '\n'.join([stmt.code for stmt in setup_stmts])
+    setup_code = RawCode('\n'.join([stmt.code for stmt in setup_stmts]))
 
     # now let's run stuff dangerously!
     user_globals = setup_user_globals()
-    exec(setup_code, user_globals)
+
+    try:
+        exec(setup_code, user_globals)
+    except serializable_errors as error:
+        step = EvalError.from_code(setup_code)
+        return [RuntimeErrorResult(step=step, args={}, val=error)]
 
     last_val: t.Any = None
     eval_results = []
     for step in last_expr.chain:
-        # wrap individual steps in parens before eval since subexpressions
-        # within a line can have newlines
-        val = eval(f"({step.code})", user_globals)
-        args = eval_args(step, user_globals)
+        try:
+            # wrap individual steps in parens before eval since subexpressions
+            # within a line can have newlines
+            val = eval(f"({step.code})", user_globals)
+            args = eval_args(step, user_globals)
+        except serializable_errors as error:
+            step = EvalError.from_code(step.code)
+            result = RuntimeErrorResult(step=step, args={}, val=error)
+            eval_results.append(result)
+            break
+
         result = make_result(step, val, args, last_val)
         eval_results.append(result)
         last_val = val

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -91,7 +91,7 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
         return [RuntimeErrorResult(step=step, args={}, val=error)]
 
     last_val: t.Any = None
-    eval_results = []
+    eval_results: t.List[EvalResult] = []
     for step in last_expr.chain:
         try:
             # wrap individual steps in parens before eval since subexpressions
@@ -100,8 +100,8 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
             args = eval_args(step, user_globals)
         except serializable_errors as error:
             step = EvalError.from_code(step.code)
-            result = RuntimeErrorResult(step=step, args={}, val=error)
-            eval_results.append(result)
+            err_result = RuntimeErrorResult(step=step, args={}, val=error)
+            eval_results.append(err_result)
             break
 
         result = make_result(step, val, args, last_val)

--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -3,20 +3,32 @@ serializes run.py outputs into json.
 '''
 
 from __future__ import annotations
+from traceback import TracebackException
 
 import typing as t
 
 from . import util
-from .diagram import (DataPair, DataSpec, DFSpec, Diagram, Group, GroupBySpec,
-                      GroupData, SeriesGroupBySpec, SeriesSpec, UnhandledData)
+from .diagram import (DataPair, DataSpec, DFSpec, Diagram, ErrorOutput,
+                      Explanation, Group, GroupBySpec, GroupData,
+                      SeriesGroupBySpec, SeriesSpec, UnhandledData)
 from .marks import make_marks
-from .run import (DFResult, EvalResult, GroupbyResult, SeriesGroupbyResult,
-                  SeriesResult)
+from .run import (DFResult, EvalResult, GroupbyResult, RuntimeErrorResult,
+                  SeriesGroupbyResult, SeriesResult)
 
 T = t.TypeVar('T')
 
 
-def serialize(results: t.List[EvalResult]) -> t.List[Diagram]:
+def serialize(results: t.List[EvalResult]) -> Explanation:
+    if len(results) == 0:
+        return []
+    elif len(results) == 1:
+        # happens when user inputs `df` without a function call, or when
+        # error happens in setup code
+        result = results[0]
+        if isinstance(result, RuntimeErrorResult):
+            error_output = serialize_error(result)
+            return [error_output]
+        return []
     return [
         serialize_one_step(before, after) for before, after in pairs(results)
     ]
@@ -27,7 +39,17 @@ def serialize_to_json(results: t.List[EvalResult]) -> str:
     return Diagram.to_json(diagrams)
 
 
-def serialize_one_step(before: EvalResult, after: EvalResult) -> Diagram:
+def serialize_error(result: RuntimeErrorResult) -> ErrorOutput:
+    tb = TracebackException.from_exception(result.val)
+    # get error message from last stack frame
+    message = list(tb.format_exception_only())[-1]
+    return ErrorOutput(code_step=result.step.code, message=message)
+
+
+def serialize_one_step(before: EvalResult,
+                       after: EvalResult) -> t.Union[Diagram, ErrorOutput]:
+    if isinstance(after, RuntimeErrorResult):
+        return serialize_error(after)
     step = after.step
 
     marks = make_marks(step, before, after)
@@ -61,7 +83,7 @@ def serialize_step_val(step: EvalResult) -> DataSpec:
         return serialize_seriesgroupby(step.val)
     else:
         val = step.val
-        return UnhandledData(data=str(val))
+        return UnhandledData(data=repr(val))
 
 
 def serialize_groupby(val: util.DataFrameGroupBy) -> GroupBySpec:

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs
+ .loc[:, ['not_a_column']]
+ .sort_values('kids')
+)

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py.golden
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ErrorOutput",
+    "code_step": "dogs\n .loc[:, ['not_a_column']]",
+    "message": "KeyError: \"None of [Index(['not_a_column'], dtype='object')] are in the [columns]\"\n"
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs
+ .sort_values('kids')
+ .loc[:, ['not_a_column']]
+)

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
@@ -1,0 +1,245 @@
+[
+  {
+    "type": "SortValuesCall",
+    "code_step": "dogs\n .sort_values('kids')",
+    "mapping": [
+      {
+        "select": "column",
+        "anchor": "rhs",
+        "label": "kids",
+        "illustrate": "highlight"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 0
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 0
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 1
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 1
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 2
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 2
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 3
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 3
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 4
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 4
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 5
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 5
+        },
+        "illustrate": "outline"
+      },
+      {
+        "select": "row",
+        "from": {
+          "anchor": "lhs",
+          "label": 6
+        },
+        "to": {
+          "anchor": "rhs",
+          "label": 6
+        },
+        "illustrate": "outline"
+      }
+    ],
+    "data_frame": {
+      "lhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ]
+        ]
+      },
+      "rhs": {
+        "type": "DataFrame",
+        "col_names": [
+          "breed",
+          "grooming",
+          "food_cost",
+          "kids",
+          "size"
+        ],
+        "row_labels": [
+          0,
+          2,
+          3,
+          6,
+          4,
+          1,
+          5
+        ],
+        "data": [
+          [
+            "Labrador Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Beagle",
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ],
+          [
+            "Golden Retriever",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Boxer",
+            "weekly",
+            466.0,
+            "high",
+            "medium"
+          ],
+          [
+            "Yorkshire Terrier",
+            "daily",
+            324.0,
+            "low",
+            "small"
+          ],
+          [
+            "German Shepherd",
+            "weekly",
+            466.0,
+            "medium",
+            "large"
+          ],
+          [
+            "Bulldog",
+            "weekly",
+            466.0,
+            "medium",
+            "medium"
+          ]
+        ]
+      }
+    }
+  },
+  {
+    "type": "ErrorOutput",
+    "code_step": "(dogs\n .sort_values('kids')\n .loc[:, ['not_a_column']]\n)",
+    "message": "KeyError: \"None of [Index(['not_a_column'], dtype='object')] are in the [columns]\"\n"
+  }
+]

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(some_random_var_name))
+
+(dogs
+ .apply(lambda x: x * 2)
+)

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py.golden
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ErrorOutput",
+    "code_step": "import pandas as pd\nimport io\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\ndogs = pd.read_csv(io.StringIO(some_random_var_name))",
+    "message": "NameError: name 'some_random_var_name' is not defined\n"
+  }
+]


### PR DESCRIPTION
handle runtime errors

when executing user code, we'll try to run as many steps as possible until
the first error. then we'll stick the error message into the JSON:

https://github.com/SamLau95/pandas_tutor/blob/aa8ba706db399334f0f0d386e146098617756463/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py.golden#L2-L6

right now we aren't grabbing the line numbers since it's tricky to do
so---since we're passing in individual lines of code into `eval`, it doesn't
produce the right line numbers by default when an error happens. if that ends
up being important i can take a closer look.

