### PR TITLE
add fragment locations to spec

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -12,6 +12,8 @@ import typing as t
 import numpy as np
 import pandas as pd
 
+from .util import CodeRange
+
 # technically dataframe labels can be all sorts of things...
 # TODO: handle other index dtypes
 Label = t.Union[int, str]
@@ -53,6 +55,7 @@ def encode_pd_objs(obj: t.Any):
 class Diagram:
     type: str
     code_step: str
+    fragment: CodeRange
     mapping: t.List[Mark]
 
     # although we call this data_frame, technically it can hold any type of

--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -12,12 +12,7 @@ import typing as t
 import numpy as np
 import pandas as pd
 
-from .util import CodeRange
-
-# technically dataframe labels can be all sorts of things...
-# TODO: handle other index dtypes
-Label = t.Union[int, str]
-Labels = t.Union[t.List[int], t.List[str]]
+from .util import CodeRange, Labels, Label
 
 
 def _diagram_as_dict(dclass):

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -23,11 +23,11 @@ import libcst.matchers as m
 import libcst.metadata as cstm
 
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStatement,
-                          CodePosition, GroupByCall, HeadCall, ParsedModule,
-                          ParseError, PassThroughCall, RawCode, RenameCall,
-                          SortValuesCall, StartOfChain, SubsComparison,
-                          Subscript, SubscriptEl, SubsEval, SubsSlice,
-                          TailCall, VerbatimStatement)
+                          GroupByCall, HeadCall, ParsedModule, ParseError,
+                          PassThroughCall, RawCode, RenameCall, SortValuesCall,
+                          StartOfChain, SubsComparison, Subscript, SubscriptEl,
+                          SubsEval, SubsSlice, TailCall, VerbatimStatement)
+from .util import CodePosition, CodeRange
 
 T = t.TypeVar('T')
 
@@ -39,8 +39,7 @@ def parse(code: str) -> t.Union[ParsedModule, ParseError]:
         pos = CodePosition(e.editor_line - 1, e.editor_column)
         return ParseError(code=RawCode(code),
                           error_msg=str(e),
-                          start=pos,
-                          end=pos)
+                          location=CodeRange(pos, pos))
 
     with_meta = cstm.MetadataWrapper(tree)
     sam = PandasParser()
@@ -461,20 +460,19 @@ class PandasParser(m.MatcherDecoratableVisitor):
     def code_for(self, cst_node):
         return RawCode(self.cst_root.code_for_node(cst_node))
 
-    def make_positions(self, cst_node) -> t.Tuple[CodePosition, CodePosition]:
+    def location(self, cst_node) -> CodeRange:
         meta = t.cast(cstm.CodeRange,
                       self.get_metadata(cstm.PositionProvider, cst_node))
 
         # subtract 1 from line to make everything 0-indexed
-        return (
-            CodePosition(line=meta.start.line - 1, ch=meta.start.column),
-            CodePosition(line=meta.end.line - 1, ch=meta.end.column),
-        )
+        start = CodePosition(line=meta.start.line - 1, ch=meta.start.column)
+        end = CodePosition(line=meta.end.line - 1, ch=meta.end.column)
+        return CodeRange(start, end)
 
     def make_node(self, cls: t.Type[T], cst_node: cst.CSTNode, **kwargs) -> T:
         code = self.code_for(cst_node)
-        start, end = self.make_positions(cst_node)
-        return cls(code=code, start=start, end=end, **kwargs)  # type: ignore
+        location = self.location(cst_node)
+        return cls(code=code, location=location, **kwargs)  # type: ignore
 
 
 whitespace = (m.Comment() | m.EmptyLine() | m.Newline()

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -8,6 +8,8 @@ import json
 import typing as t
 from dataclasses import field
 
+from .util import NULL_LOC, CodeRange
+
 # Use a distinct type to distinguish between strings that can be eval'd
 RawCode = t.NewType('RawCode', str)
 
@@ -20,21 +22,10 @@ class _ParseTreeEncoder(json.JSONEncoder):
 
 
 @dataclasses.dataclass
-class CodePosition:
-    '''
-    points to a location within the original code string. both lines and
-    columns are 0-indexed
-    '''
-    line: int
-    ch: int
-
-
-@dataclasses.dataclass
 class Base:
     type_: str = field(init=False, repr=False)
     code: RawCode
-    start: CodePosition
-    end: CodePosition
+    location: CodeRange
 
     def __post_init__(self):
         self.type_ = self.__class__.__name__
@@ -202,7 +193,7 @@ class AggCall(Base):
 
     @classmethod
     def from_passthrough_call(cls, call: PassThroughCall):
-        return cls(code=call.code, start=call.start, end=call.end)
+        return cls(code=call.code, location=call.location)
 
 
 @dataclasses.dataclass
@@ -301,8 +292,6 @@ SubscriptEl = t.Union[SubsSlice, SubsComparison, SubsEval]
 # Errors
 ##############################################################################
 
-_dummy_code_position = CodePosition(-999, -999)
-
 
 @dataclasses.dataclass
 class EvalError(Base):
@@ -310,7 +299,7 @@ class EvalError(Base):
     # TODO: compute code positions for errors
     @classmethod
     def from_code(cls, code: RawCode):
-        return cls(code, start=_dummy_code_position, end=_dummy_code_position)
+        return cls(code, location=NULL_LOC)
 
 
 ##############################################################################

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -32,7 +32,7 @@ serializable_errors = (ArithmeticError, AttributeError, ImportError,
 class EvalBase:
     step: ChainStep
     # location of fragment to highlight, relative to the entire expression
-    relative_loc: CodeRange
+    fragment: CodeRange
     args: Args
 
 
@@ -99,7 +99,7 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
         return [
             RuntimeErrorResult(
                 step=step,
-                relative_loc=step.location,
+                fragment=step.location,
                 args={},
                 val=error,
             )
@@ -110,7 +110,7 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
     last_val: t.Any = None
     eval_results: t.List[EvalResult] = []
     for step in last_expr.chain:
-        relative_loc = (step.location - last_location) % relative_to
+        fragment = (step.location - last_location) % relative_to
 
         try:
             # wrap individual steps in parens before eval since subexpressions
@@ -121,24 +121,25 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
             step = EvalError.from_code(step.code)
             err_result = RuntimeErrorResult(
                 step=step,
-                relative_loc=relative_loc,
+                fragment=fragment,
                 args={},
                 val=error,
             )
             eval_results.append(err_result)
             break
 
-        result = make_result(step, relative_loc, args, val, last_val)
+        result = make_result(step, fragment, args, val, last_val)
         eval_results.append(result)
         last_val = val
+        last_location = step.location
 
     return eval_results
 
 
 # need the last_val for the special case where we have an agg that doesn't show
 # up immediately after a groupby, like dogs.groupby(...)['...'].mean().
-def make_result(step: ChainStep, relative_loc: CodeRange, args: Args,
-                val: t.Any, last_val: t.Any) -> EvalResult:
+def make_result(step: ChainStep, fragment: CodeRange, args: Args, val: t.Any,
+                last_val: t.Any) -> EvalResult:
     if (isinstance(step, PassThroughCall)
             and isinstance(last_val,
                            (util.DataFrameGroupBy, util.SeriesGroupBy))
@@ -146,17 +147,17 @@ def make_result(step: ChainStep, relative_loc: CodeRange, args: Args,
         step = AggCall.from_passthrough_call(step)
 
     if isinstance(val, util.DataFrameGroupBy):
-        return GroupbyResult(step, relative_loc, args, val)
+        return GroupbyResult(step, fragment, args, val)
     elif isinstance(val, util.SeriesGroupBy):
-        return SeriesGroupbyResult(step, relative_loc, args, val)
+        return SeriesGroupbyResult(step, fragment, args, val)
     elif isinstance(val, pd.DataFrame):
-        return DFResult(step, relative_loc, args, val)
+        return DFResult(step, fragment, args, val)
     elif isinstance(val, pd.Series):
-        return SeriesResult(step, relative_loc, args, val)
+        return SeriesResult(step, fragment, args, val)
     elif util.is_plottable(val):
-        return ImageResult(step, relative_loc, args, val)
+        return ImageResult(step, fragment, args, val)
     else:
-        return UnhandledResult(step, relative_loc, args, val)
+        return UnhandledResult(step, fragment, args, val)
 
 
 def setup_user_globals():

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -13,8 +13,9 @@ import typing as t
 import pandas as pd
 
 from . import util
-from .parse_nodes import (AggCall, ChainStatement, ChainStep, EvalError,
-                          ParsedModule, PassThroughCall, RawCode, Subscript)
+from .parse_nodes import (AggCall, ChainStatement, ChainStep, CodeRange,
+                          EvalError, ParsedModule, PassThroughCall, RawCode,
+                          Subscript, NULL_LOC)
 
 # technically args can be anything...but most of the time it'll be labels
 Arg = t.Union[str, t.List[str]]
@@ -30,6 +31,8 @@ serializable_errors = (ArithmeticError, AttributeError, ImportError,
 @dataclasses.dataclass
 class EvalBase:
     step: ChainStep
+    # location of fragment to highlight, relative to the entire expression
+    relative_loc: CodeRange
     args: Args
 
 
@@ -93,11 +96,22 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
         exec(setup_code, user_globals)
     except serializable_errors as error:
         step = EvalError.from_code(setup_code)
-        return [RuntimeErrorResult(step=step, args={}, val=error)]
+        return [
+            RuntimeErrorResult(
+                step=step,
+                relative_loc=step.location,
+                args={},
+                val=error,
+            )
+        ]
 
+    relative_to = last_expr.location.start
+    last_location = NULL_LOC
     last_val: t.Any = None
     eval_results: t.List[EvalResult] = []
     for step in last_expr.chain:
+        relative_loc = (step.location - last_location) % relative_to
+
         try:
             # wrap individual steps in parens before eval since subexpressions
             # within a line can have newlines
@@ -105,11 +119,16 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
             args = eval_args(step, user_globals)
         except serializable_errors as error:
             step = EvalError.from_code(step.code)
-            err_result = RuntimeErrorResult(step=step, args={}, val=error)
+            err_result = RuntimeErrorResult(
+                step=step,
+                relative_loc=relative_loc,
+                args={},
+                val=error,
+            )
             eval_results.append(err_result)
             break
 
-        result = make_result(step, val, args, last_val)
+        result = make_result(step, relative_loc, args, val, last_val)
         eval_results.append(result)
         last_val = val
 
@@ -118,8 +137,8 @@ def run(root: ParsedModule) -> t.List[EvalResult]:
 
 # need the last_val for the special case where we have an agg that doesn't show
 # up immediately after a groupby, like dogs.groupby(...)['...'].mean().
-def make_result(step: ChainStep, val: t.Any, args: Args,
-                last_val: t.Any) -> EvalResult:
+def make_result(step: ChainStep, relative_loc: CodeRange, args: Args,
+                val: t.Any, last_val: t.Any) -> EvalResult:
     if (isinstance(step, PassThroughCall)
             and isinstance(last_val,
                            (util.DataFrameGroupBy, util.SeriesGroupBy))
@@ -127,17 +146,17 @@ def make_result(step: ChainStep, val: t.Any, args: Args,
         step = AggCall.from_passthrough_call(step)
 
     if isinstance(val, util.DataFrameGroupBy):
-        return GroupbyResult(step, args, val)
+        return GroupbyResult(step, relative_loc, args, val)
     elif isinstance(val, util.SeriesGroupBy):
-        return SeriesGroupbyResult(step, args, val)
+        return SeriesGroupbyResult(step, relative_loc, args, val)
     elif isinstance(val, pd.DataFrame):
-        return DFResult(step, args, val)
+        return DFResult(step, relative_loc, args, val)
     elif isinstance(val, pd.Series):
-        return SeriesResult(step, args, val)
+        return SeriesResult(step, relative_loc, args, val)
     elif util.is_plottable(val):
-        return ImageResult(step, args, val)
+        return ImageResult(step, relative_loc, args, val)
     else:
-        return UnhandledResult(step, args, val)
+        return UnhandledResult(step, relative_loc, args, val)
 
 
 def setup_user_globals():

--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -65,6 +65,7 @@ def serialize_one_step(before: EvalResult,
 
     return Diagram(type=step.type_,
                    code_step=step.code,
+                   fragment=after.fragment,
                    mapping=marks,
                    data_frame=df_pair)
 

--- a/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "ApplyCall",
     "code_step": "(dogs\n .apply(lambda x: x * 2)\n)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 24
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs['breed']",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 0,
+        "ch": 14
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -107,6 +117,16 @@
   {
     "type": "ApplyCall",
     "code_step": "(dogs['breed']\n .apply(len)\n)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 14
+      },
+      "end": {
+        "line": 1,
+        "ch": 12
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "AssignCall",
     "code_step": "(dogs\n .assign(daily=lambda df: df['food_cost'] * 30)\n)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 47
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "AssignCall",
     "code_step": "(dogs.assign(daily=lambda df: df['food_cost'] * 30,\n             yearly=lambda df: df['daily'] / 365,\n             s=dogs['size'].str[0]))",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 2,
+        "ch": 35
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "AssignCall",
     "code_step": "(dogs\n .assign(test='hello world')\n)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 28
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "AssignCall",
     "code_step": "(dogs\n .assign(daily=dogs['food_cost'] * 30)\n)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 38
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "dogs\n .sort_values('kids')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 21
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/error_syntax_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_syntax_01.py.golden
@@ -1,13 +1,15 @@
 {
   "type_": "ParseError",
   "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\n# missing parens\ndogs = pd.read_csv io.StringIO(csv)\n\n(dogs\n .apply(lambda x: x * 2)\n)\n",
-  "start": {
-    "line": 15,
-    "ch": 20
-  },
-  "end": {
-    "line": 15,
-    "ch": 20
+  "location": {
+    "start": {
+      "line": 15,
+      "ch": 20
+    },
+    "end": {
+      "line": 15,
+      "ch": 20
+    }
   },
   "error_msg": "Syntax Error @ 16:20.\nIncomplete input. Encountered 'io', but expected ';', or 'NEWLINE'.\n\ndogs = pd.read_csv io.StringIO(csv)\n                   ^"
 }

--- a/pandas_tutor/tests/e2e_golden/error_syntax_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_syntax_02.py.golden
@@ -1,13 +1,15 @@
 {
   "type_": "ParseError",
   "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\ndogs\n .apply(lambda x: x * 2)\n\n",
-  "start": {
-    "line": 17,
-    "ch": 2
-  },
-  "end": {
-    "line": 17,
-    "ch": 2
+  "location": {
+    "start": {
+      "line": 17,
+      "ch": 2
+    },
+    "end": {
+      "line": 17,
+      "ch": 2
+    }
   },
   "error_msg": "Syntax Error @ 18:2.\nIncomplete input. Unexpectedly encountered an indent.\n\n .apply(lambda x: x * 2)\n ^"
 }

--- a/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.loc[:, df.iloc[0] % 2 == 0]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 30
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df[(df['Count'] > 14000) & (df['Sex'] == 'F')]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 46
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.loc[(df['Count'] > 14000) & (df['Sex'] == 'F')]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 50
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df[df['Count'] > 14000]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 23
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "GroupByCall",
     "code_step": "dogs\n .groupby('size')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 17
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -191,6 +201,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs\n .groupby('size')\n ['food_cost']",
+    "fragment": {
+      "start": {
+        "line": 1,
+        "ch": 17
+      },
+      "end": {
+        "line": 2,
+        "ch": 14
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {
@@ -359,6 +379,16 @@
   {
     "type": "AggCall",
     "code_step": "(dogs\n .groupby('size')\n ['food_cost']\n .mean()\n)",
+    "fragment": {
+      "start": {
+        "line": 2,
+        "ch": 14
+      },
+      "end": {
+        "line": 3,
+        "ch": 8
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "GroupByCall",
     "code_step": "dogs\n .groupby('grooming')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 21
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -184,6 +194,16 @@
   {
     "type": "AggCall",
     "code_step": "(dogs\n .groupby('grooming')\n .max()\n)",
+    "fragment": {
+      "start": {
+        "line": 1,
+        "ch": 21
+      },
+      "end": {
+        "line": 2,
+        "ch": 7
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "GroupByCall",
     "code_step": "dogs\n .groupby('grooming')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 21
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -184,6 +194,16 @@
   {
     "type": "AggCall",
     "code_step": "(dogs\n .groupby('grooming')\n .agg('mean')\n)",
+    "fragment": {
+      "start": {
+        "line": 1,
+        "ch": 21
+      },
+      "end": {
+        "line": 2,
+        "ch": 13
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "GroupByCall",
     "code_step": "pm.groupby(months)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 18
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -183,6 +193,16 @@
   {
     "type": "AggCall",
     "code_step": "pm.groupby(months).mean()",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 18
+      },
+      "end": {
+        "line": 0,
+        "ch": 25
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/head_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "HeadCall",
     "code_step": "dogs.head(3)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 12
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.iloc[2:5, 1:4]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 17
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.iloc[2:5]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 12
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "(dogs['breed'])",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 0,
+        "ch": 14
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "(dogs.loc[:, 'food_cost'])",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 0,
+        "ch": 25
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.loc[1:5, ['Name', 'Count']]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 30
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "df.loc[:, ['Name', 'Count']]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 28
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "dogs.sort_values('kids')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 24
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -240,6 +250,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs.sort_values('kids').iloc[0:6]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 24
+      },
+      "end": {
+        "line": 0,
+        "ch": 34
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "dogs.sort_values('kids')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 24
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -240,6 +250,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs.sort_values('kids').loc[0:6]",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 24
+      },
+      "end": {
+        "line": 0,
+        "ch": 33
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "df2.sort_values('two')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 3
+      },
+      "end": {
+        "line": 0,
+        "ch": 22
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/plot_end_of_chain.py.golden
+++ b/pandas_tutor/tests/e2e_golden/plot_end_of_chain.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "GroupByCall",
     "code_step": "dogs\n .groupby('size')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 5
+      },
+      "end": {
+        "line": 1,
+        "ch": 17
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -191,6 +201,16 @@
   {
     "type": "AggCall",
     "code_step": "dogs\n .groupby('size')\n .mean()",
+    "fragment": {
+      "start": {
+        "line": 1,
+        "ch": 17
+      },
+      "end": {
+        "line": 2,
+        "ch": 8
+      }
+    },
     "mapping": [
       {
         "select": "row",
@@ -410,6 +430,16 @@
   {
     "type": "PassThroughCall",
     "code_step": "(dogs\n .groupby('size')\n .mean()\n .plot(kind='bar')\n)",
+    "fragment": {
+      "start": {
+        "line": 2,
+        "ch": 8
+      },
+      "end": {
+        "line": 3,
+        "ch": 18
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/plot_seaborn.py.golden
+++ b/pandas_tutor/tests/e2e_golden/plot_seaborn.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "PassThroughCall",
     "code_step": "sns.catplot(data=dogs, x='food_cost', y='grooming', kind='bar')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 3
+      },
+      "end": {
+        "line": 0,
+        "ch": 63
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/plot_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/plot_simple.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "PassThroughCall",
     "code_step": "dogs.plot()",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 11
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "RenameCall",
     "code_step": "dogs.rename(columns={'breed': 'b', 'food_cost': 'cost'})",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 56
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "RenameCall",
     "code_step": "dogs.rename(columns=renamer)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 28
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "RenameCall",
     "code_step": "dogs.rename(index={0: 'hello', 1: 'world'})",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 43
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs['food_cost']",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 17
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -107,6 +117,16 @@
   {
     "type": "PassThroughCall",
     "code_step": "dogs['food_cost'].mean()",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 17
+      },
+      "end": {
+        "line": 0,
+        "ch": 24
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "Subscript",
     "code_step": "dogs['breed']",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 13
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -107,6 +117,16 @@
   {
     "type": "PassThroughCall",
     "code_step": "dogs['breed'].to_frame()",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 13
+      },
+      "end": {
+        "line": 0,
+        "ch": 24
+      }
+    },
     "mapping": [],
     "data_frame": {
       "lhs": {

--- a/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "df.sort_values('Name')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 22
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "df.sort_values(axis=0, by='Name')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 33
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "df.sort_values('Name')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 2
+      },
+      "end": {
+        "line": 0,
+        "ch": 22
+      }
+    },
     "mapping": [
       {
         "select": "column",
@@ -302,6 +312,16 @@
   {
     "type": "SortValuesCall",
     "code_step": "df.sort_values('Name').sort_values('Count')",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 22
+      },
+      "end": {
+        "line": 0,
+        "ch": 43
+      }
+    },
     "mapping": [
       {
         "select": "column",

--- a/pandas_tutor/tests/e2e_golden/tail_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_01.py.golden
@@ -2,6 +2,16 @@
   {
     "type": "TailCall",
     "code_step": "dogs.tail(2)",
+    "fragment": {
+      "start": {
+        "line": 0,
+        "ch": 4
+      },
+      "end": {
+        "line": 0,
+        "ch": 12
+      }
+    },
     "mapping": [
       {
         "select": "row",

--- a/pandas_tutor/tests/parse_golden/basic_chain.py.golden
+++ b/pandas_tutor/tests/parse_golden/basic_chain.py.golden
@@ -1,49 +1,57 @@
 {
   "type_": "ParsedModule",
   "code": "(df\n .sort_values('Name')\n .loc[:, 'Count']\n)",
-  "start": {
-    "line": 0,
-    "ch": 0
-  },
-  "end": {
-    "line": 4,
-    "ch": 0
+  "location": {
+    "start": {
+      "line": 0,
+      "ch": 0
+    },
+    "end": {
+      "line": 4,
+      "ch": 0
+    }
   },
   "statements": [
     {
       "type_": "ChainStatement",
       "code": "(df\n .sort_values('Name')\n .loc[:, 'Count']\n)",
-      "start": {
-        "line": 0,
-        "ch": 0
-      },
-      "end": {
-        "line": 3,
-        "ch": 1
+      "location": {
+        "start": {
+          "line": 0,
+          "ch": 0
+        },
+        "end": {
+          "line": 3,
+          "ch": 1
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 0,
-            "ch": 1
-          },
-          "end": {
-            "line": 0,
-            "ch": 3
+          "location": {
+            "start": {
+              "line": 0,
+              "ch": 1
+            },
+            "end": {
+              "line": 0,
+              "ch": 3
+            }
           }
         },
         {
           "type_": "SortValuesCall",
           "code": "df\n .sort_values('Name')",
-          "start": {
-            "line": 0,
-            "ch": 1
-          },
-          "end": {
-            "line": 1,
-            "ch": 21
+          "location": {
+            "start": {
+              "line": 0,
+              "ch": 1
+            },
+            "end": {
+              "line": 1,
+              "ch": 21
+            }
           },
           "label_expr": "'Name'",
           "axis": "index"
@@ -51,37 +59,43 @@
         {
           "type_": "Subscript",
           "code": "(df\n .sort_values('Name')\n .loc[:, 'Count']\n)",
-          "start": {
-            "line": 0,
-            "ch": 1
-          },
-          "end": {
-            "line": 2,
-            "ch": 17
+          "location": {
+            "start": {
+              "line": 0,
+              "ch": 1
+            },
+            "end": {
+              "line": 2,
+              "ch": 17
+            }
           },
           "slicer": "loc",
           "slice1": {
             "type_": "SubsSlice",
             "code": ":",
-            "start": {
-              "line": 2,
-              "ch": 6
-            },
-            "end": {
-              "line": 2,
-              "ch": 7
+            "location": {
+              "start": {
+                "line": 2,
+                "ch": 6
+              },
+              "end": {
+                "line": 2,
+                "ch": 7
+              }
             }
           },
           "slice2": {
             "type_": "SubsEval",
             "code": "'Count'",
-            "start": {
-              "line": 2,
-              "ch": 9
-            },
-            "end": {
-              "line": 2,
-              "ch": 16
+            "location": {
+              "start": {
+                "line": 2,
+                "ch": 9
+              },
+              "end": {
+                "line": 2,
+                "ch": 16
+              }
             },
             "expr": "'Count'"
           }

--- a/pandas_tutor/tests/parse_golden/filter_01.py.golden
+++ b/pandas_tutor/tests/parse_golden/filter_01.py.golden
@@ -1,85 +1,99 @@
 {
   "type_": "ParsedModule",
   "code": "import pandas as pd\n\ndf = pd.DataFrame([('Liam', 'M', 19659, 2020), ('Noah', 'M', 18252, 2020),\n                   ('Oliver', 'M', 14147, 2020), ('Elijah', 'M', 13034, 2020),\n                   ('William', 'M', 12541, 2020), ('Emma', 'F', 15581, 2020),\n                   ('Ava', 'F', 13084, 2020), ('Charlotte', 'F', 13003, 2020),\n                   ('Sophia', 'F', 12976, 2020), ('Amelia', 'F', 12704, 2020)],\n                  columns=['Name', 'Sex', 'Count', 'Year'])\n\ndf[df['Count'] > 13000]\n",
-  "start": {
-    "line": 0,
-    "ch": 0
-  },
-  "end": {
-    "line": 10,
-    "ch": 0
+  "location": {
+    "start": {
+      "line": 0,
+      "ch": 0
+    },
+    "end": {
+      "line": 10,
+      "ch": 0
+    }
   },
   "statements": [
     {
       "type_": "VerbatimStatement",
       "code": "import pandas as pd",
-      "start": {
-        "line": 0,
-        "ch": 0
-      },
-      "end": {
-        "line": 0,
-        "ch": 19
+      "location": {
+        "start": {
+          "line": 0,
+          "ch": 0
+        },
+        "end": {
+          "line": 0,
+          "ch": 19
+        }
       }
     },
     {
       "type_": "VerbatimStatement",
       "code": "df = pd.DataFrame([('Liam', 'M', 19659, 2020), ('Noah', 'M', 18252, 2020),\n                   ('Oliver', 'M', 14147, 2020), ('Elijah', 'M', 13034, 2020),\n                   ('William', 'M', 12541, 2020), ('Emma', 'F', 15581, 2020),\n                   ('Ava', 'F', 13084, 2020), ('Charlotte', 'F', 13003, 2020),\n                   ('Sophia', 'F', 12976, 2020), ('Amelia', 'F', 12704, 2020)],\n                  columns=['Name', 'Sex', 'Count', 'Year'])",
-      "start": {
-        "line": 2,
-        "ch": 0
-      },
-      "end": {
-        "line": 7,
-        "ch": 59
+      "location": {
+        "start": {
+          "line": 2,
+          "ch": 0
+        },
+        "end": {
+          "line": 7,
+          "ch": 59
+        }
       }
     },
     {
       "type_": "ChainStatement",
       "code": "df[df['Count'] > 13000]",
-      "start": {
-        "line": 9,
-        "ch": 0
-      },
-      "end": {
-        "line": 9,
-        "ch": 23
+      "location": {
+        "start": {
+          "line": 9,
+          "ch": 0
+        },
+        "end": {
+          "line": 9,
+          "ch": 23
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[df['Count'] > 13000]",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 23
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 23
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsComparison",
             "code": "df['Count'] > 13000",
-            "start": {
-              "line": 9,
-              "ch": 3
-            },
-            "end": {
-              "line": 9,
-              "ch": 22
+            "location": {
+              "start": {
+                "line": 9,
+                "ch": 3
+              },
+              "end": {
+                "line": 9,
+                "ch": 22
+              }
             },
             "label_exprs": [
               "'Count'"

--- a/pandas_tutor/tests/parse_golden/loc_one_val_01.py.golden
+++ b/pandas_tutor/tests/parse_golden/loc_one_val_01.py.golden
@@ -1,98 +1,114 @@
 {
   "type_": "ParsedModule",
   "code": "import pandas as pd\n\ndf = pd.DataFrame([('Liam', 'M', 19659, 2020), ('Noah', 'M', 18252, 2020),\n                   ('Oliver', 'M', 14147, 2020), ('Elijah', 'M', 13034, 2020),\n                   ('William', 'M', 12541, 2020), ('Emma', 'F', 15581, 2020),\n                   ('Ava', 'F', 13084, 2020), ('Charlotte', 'F', 13003, 2020),\n                   ('Sophia', 'F', 12976, 2020), ('Amelia', 'F', 12704, 2020)],\n                  columns=['Name', 'Sex', 'Count', 'Year'])\n\ndf.loc[1, 'Name']\n",
-  "start": {
-    "line": 0,
-    "ch": 0
-  },
-  "end": {
-    "line": 10,
-    "ch": 0
+  "location": {
+    "start": {
+      "line": 0,
+      "ch": 0
+    },
+    "end": {
+      "line": 10,
+      "ch": 0
+    }
   },
   "statements": [
     {
       "type_": "VerbatimStatement",
       "code": "import pandas as pd",
-      "start": {
-        "line": 0,
-        "ch": 0
-      },
-      "end": {
-        "line": 0,
-        "ch": 19
+      "location": {
+        "start": {
+          "line": 0,
+          "ch": 0
+        },
+        "end": {
+          "line": 0,
+          "ch": 19
+        }
       }
     },
     {
       "type_": "VerbatimStatement",
       "code": "df = pd.DataFrame([('Liam', 'M', 19659, 2020), ('Noah', 'M', 18252, 2020),\n                   ('Oliver', 'M', 14147, 2020), ('Elijah', 'M', 13034, 2020),\n                   ('William', 'M', 12541, 2020), ('Emma', 'F', 15581, 2020),\n                   ('Ava', 'F', 13084, 2020), ('Charlotte', 'F', 13003, 2020),\n                   ('Sophia', 'F', 12976, 2020), ('Amelia', 'F', 12704, 2020)],\n                  columns=['Name', 'Sex', 'Count', 'Year'])",
-      "start": {
-        "line": 2,
-        "ch": 0
-      },
-      "end": {
-        "line": 7,
-        "ch": 59
+      "location": {
+        "start": {
+          "line": 2,
+          "ch": 0
+        },
+        "end": {
+          "line": 7,
+          "ch": 59
+        }
       }
     },
     {
       "type_": "ChainStatement",
       "code": "df.loc[1, 'Name']",
-      "start": {
-        "line": 9,
-        "ch": 0
-      },
-      "end": {
-        "line": 9,
-        "ch": 17
+      "location": {
+        "start": {
+          "line": 9,
+          "ch": 0
+        },
+        "end": {
+          "line": 9,
+          "ch": 17
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df.loc[1, 'Name']",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 17
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 17
+            }
           },
           "slicer": "loc",
           "slice1": {
             "type_": "SubsEval",
             "code": "1",
-            "start": {
-              "line": 9,
-              "ch": 7
-            },
-            "end": {
-              "line": 9,
-              "ch": 8
+            "location": {
+              "start": {
+                "line": 9,
+                "ch": 7
+              },
+              "end": {
+                "line": 9,
+                "ch": 8
+              }
             },
             "expr": "1"
           },
           "slice2": {
             "type_": "SubsEval",
             "code": "'Name'",
-            "start": {
-              "line": 9,
-              "ch": 10
-            },
-            "end": {
-              "line": 9,
-              "ch": 16
+            "location": {
+              "start": {
+                "line": 9,
+                "ch": 10
+              },
+              "end": {
+                "line": 9,
+                "ch": 16
+              }
             },
             "expr": "'Name'"
           }

--- a/pandas_tutor/tests/parse_golden/sort_value_args.py.golden
+++ b/pandas_tutor/tests/parse_golden/sort_value_args.py.golden
@@ -1,49 +1,57 @@
 {
   "type_": "ParsedModule",
   "code": "# Tests that parser can handle different types of args\n# import pandas as pd\n\n# df.loc[:, 'Count']\n# df[df['Count'] < 10000]\ndf.sort_values('Name')\n\ncols = ['size', 'breed']\ndf.sort_values(cols)\n\ndf.sort_values(by=['entry_id'], ascending=False)\n\ndf.sort_values(axis=1, by='Name')\n# df.groupby('Name').mean()\n# df.rename(columns={'Name': 'n'})\n",
-  "start": {
-    "line": 0,
-    "ch": 0
-  },
-  "end": {
-    "line": 15,
-    "ch": 0
+  "location": {
+    "start": {
+      "line": 0,
+      "ch": 0
+    },
+    "end": {
+      "line": 15,
+      "ch": 0
+    }
   },
   "statements": [
     {
       "type_": "ChainStatement",
       "code": "df.sort_values('Name')",
-      "start": {
-        "line": 5,
-        "ch": 0
-      },
-      "end": {
-        "line": 5,
-        "ch": 22
+      "location": {
+        "start": {
+          "line": 5,
+          "ch": 0
+        },
+        "end": {
+          "line": 5,
+          "ch": 22
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 5,
-            "ch": 0
-          },
-          "end": {
-            "line": 5,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 5,
+              "ch": 0
+            },
+            "end": {
+              "line": 5,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "SortValuesCall",
           "code": "df.sort_values('Name')",
-          "start": {
-            "line": 5,
-            "ch": 0
-          },
-          "end": {
-            "line": 5,
-            "ch": 22
+          "location": {
+            "start": {
+              "line": 5,
+              "ch": 0
+            },
+            "end": {
+              "line": 5,
+              "ch": 22
+            }
           },
           "label_expr": "'Name'",
           "axis": "index"
@@ -53,49 +61,57 @@
     {
       "type_": "VerbatimStatement",
       "code": "cols = ['size', 'breed']",
-      "start": {
-        "line": 7,
-        "ch": 0
-      },
-      "end": {
-        "line": 7,
-        "ch": 24
+      "location": {
+        "start": {
+          "line": 7,
+          "ch": 0
+        },
+        "end": {
+          "line": 7,
+          "ch": 24
+        }
       }
     },
     {
       "type_": "ChainStatement",
       "code": "df.sort_values(cols)",
-      "start": {
-        "line": 8,
-        "ch": 0
-      },
-      "end": {
-        "line": 8,
-        "ch": 20
+      "location": {
+        "start": {
+          "line": 8,
+          "ch": 0
+        },
+        "end": {
+          "line": 8,
+          "ch": 20
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 8,
-            "ch": 0
-          },
-          "end": {
-            "line": 8,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 8,
+              "ch": 0
+            },
+            "end": {
+              "line": 8,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "SortValuesCall",
           "code": "df.sort_values(cols)",
-          "start": {
-            "line": 8,
-            "ch": 0
-          },
-          "end": {
-            "line": 8,
-            "ch": 20
+          "location": {
+            "start": {
+              "line": 8,
+              "ch": 0
+            },
+            "end": {
+              "line": 8,
+              "ch": 20
+            }
           },
           "label_expr": "cols",
           "axis": "index"
@@ -105,37 +121,43 @@
     {
       "type_": "ChainStatement",
       "code": "df.sort_values(by=['entry_id'], ascending=False)",
-      "start": {
-        "line": 10,
-        "ch": 0
-      },
-      "end": {
-        "line": 10,
-        "ch": 48
+      "location": {
+        "start": {
+          "line": 10,
+          "ch": 0
+        },
+        "end": {
+          "line": 10,
+          "ch": 48
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 10,
-            "ch": 0
-          },
-          "end": {
-            "line": 10,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 10,
+              "ch": 0
+            },
+            "end": {
+              "line": 10,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "SortValuesCall",
           "code": "df.sort_values(by=['entry_id'], ascending=False)",
-          "start": {
-            "line": 10,
-            "ch": 0
-          },
-          "end": {
-            "line": 10,
-            "ch": 48
+          "location": {
+            "start": {
+              "line": 10,
+              "ch": 0
+            },
+            "end": {
+              "line": 10,
+              "ch": 48
+            }
           },
           "label_expr": "['entry_id']",
           "axis": "index"
@@ -145,37 +167,43 @@
     {
       "type_": "ChainStatement",
       "code": "df.sort_values(axis=1, by='Name')",
-      "start": {
-        "line": 12,
-        "ch": 0
-      },
-      "end": {
-        "line": 12,
-        "ch": 33
+      "location": {
+        "start": {
+          "line": 12,
+          "ch": 0
+        },
+        "end": {
+          "line": 12,
+          "ch": 33
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 12,
-            "ch": 0
-          },
-          "end": {
-            "line": 12,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 12,
+              "ch": 0
+            },
+            "end": {
+              "line": 12,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "SortValuesCall",
           "code": "df.sort_values(axis=1, by='Name')",
-          "start": {
-            "line": 12,
-            "ch": 0
-          },
-          "end": {
-            "line": 12,
-            "ch": 33
+          "location": {
+            "start": {
+              "line": 12,
+              "ch": 0
+            },
+            "end": {
+              "line": 12,
+              "ch": 33
+            }
           },
           "label_expr": "'Name'",
           "axis": "columns"

--- a/pandas_tutor/tests/parse_golden/subscript_args.py.golden
+++ b/pandas_tutor/tests/parse_golden/subscript_args.py.golden
@@ -1,73 +1,85 @@
 {
   "type_": "ParsedModule",
   "code": "# Tests that parser can handle different types of susbcript args\ndf.loc[:, 'Count']\n\ndf[['Name', 'Count']]\ndf[df.columns[:4]]\n\ndf[df['Count'] < 10000]\n\ncol = 'Name'\ndf[(df[col] > 10) | (df['Year'] >= 2020)]\n\nmask = df['Count'] > 10\ndf[mask]\n\n(df\n .iloc[2:5]\n .loc[:, df['tricky'] == 'to parse']\n)\n\n(df\n [2:5]\n [df['also'] == 'tricky']\n)\n",
-  "start": {
-    "line": 0,
-    "ch": 0
-  },
-  "end": {
-    "line": 23,
-    "ch": 0
+  "location": {
+    "start": {
+      "line": 0,
+      "ch": 0
+    },
+    "end": {
+      "line": 23,
+      "ch": 0
+    }
   },
   "statements": [
     {
       "type_": "ChainStatement",
       "code": "df.loc[:, 'Count']",
-      "start": {
-        "line": 1,
-        "ch": 0
-      },
-      "end": {
-        "line": 1,
-        "ch": 18
+      "location": {
+        "start": {
+          "line": 1,
+          "ch": 0
+        },
+        "end": {
+          "line": 1,
+          "ch": 18
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 1,
-            "ch": 0
-          },
-          "end": {
-            "line": 1,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 1,
+              "ch": 0
+            },
+            "end": {
+              "line": 1,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df.loc[:, 'Count']",
-          "start": {
-            "line": 1,
-            "ch": 0
-          },
-          "end": {
-            "line": 1,
-            "ch": 18
+          "location": {
+            "start": {
+              "line": 1,
+              "ch": 0
+            },
+            "end": {
+              "line": 1,
+              "ch": 18
+            }
           },
           "slicer": "loc",
           "slice1": {
             "type_": "SubsSlice",
             "code": ":",
-            "start": {
-              "line": 1,
-              "ch": 7
-            },
-            "end": {
-              "line": 1,
-              "ch": 8
+            "location": {
+              "start": {
+                "line": 1,
+                "ch": 7
+              },
+              "end": {
+                "line": 1,
+                "ch": 8
+              }
             }
           },
           "slice2": {
             "type_": "SubsEval",
             "code": "'Count'",
-            "start": {
-              "line": 1,
-              "ch": 10
-            },
-            "end": {
-              "line": 1,
-              "ch": 17
+            "location": {
+              "start": {
+                "line": 1,
+                "ch": 10
+              },
+              "end": {
+                "line": 1,
+                "ch": 17
+              }
             },
             "expr": "'Count'"
           }
@@ -77,49 +89,57 @@
     {
       "type_": "ChainStatement",
       "code": "df[['Name', 'Count']]",
-      "start": {
-        "line": 3,
-        "ch": 0
-      },
-      "end": {
-        "line": 3,
-        "ch": 21
+      "location": {
+        "start": {
+          "line": 3,
+          "ch": 0
+        },
+        "end": {
+          "line": 3,
+          "ch": 21
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 3,
-            "ch": 0
-          },
-          "end": {
-            "line": 3,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 3,
+              "ch": 0
+            },
+            "end": {
+              "line": 3,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[['Name', 'Count']]",
-          "start": {
-            "line": 3,
-            "ch": 0
-          },
-          "end": {
-            "line": 3,
-            "ch": 21
+          "location": {
+            "start": {
+              "line": 3,
+              "ch": 0
+            },
+            "end": {
+              "line": 3,
+              "ch": 21
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsEval",
             "code": "['Name', 'Count']",
-            "start": {
-              "line": 3,
-              "ch": 3
-            },
-            "end": {
-              "line": 3,
-              "ch": 20
+            "location": {
+              "start": {
+                "line": 3,
+                "ch": 3
+              },
+              "end": {
+                "line": 3,
+                "ch": 20
+              }
             },
             "expr": "['Name', 'Count']"
           },
@@ -130,49 +150,57 @@
     {
       "type_": "ChainStatement",
       "code": "df[df.columns[:4]]",
-      "start": {
-        "line": 4,
-        "ch": 0
-      },
-      "end": {
-        "line": 4,
-        "ch": 18
+      "location": {
+        "start": {
+          "line": 4,
+          "ch": 0
+        },
+        "end": {
+          "line": 4,
+          "ch": 18
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 4,
-            "ch": 0
-          },
-          "end": {
-            "line": 4,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 4,
+              "ch": 0
+            },
+            "end": {
+              "line": 4,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[df.columns[:4]]",
-          "start": {
-            "line": 4,
-            "ch": 0
-          },
-          "end": {
-            "line": 4,
-            "ch": 18
+          "location": {
+            "start": {
+              "line": 4,
+              "ch": 0
+            },
+            "end": {
+              "line": 4,
+              "ch": 18
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsEval",
             "code": "df.columns[:4]",
-            "start": {
-              "line": 4,
-              "ch": 3
-            },
-            "end": {
-              "line": 4,
-              "ch": 17
+            "location": {
+              "start": {
+                "line": 4,
+                "ch": 3
+              },
+              "end": {
+                "line": 4,
+                "ch": 17
+              }
             },
             "expr": "df.columns[:4]"
           },
@@ -183,49 +211,57 @@
     {
       "type_": "ChainStatement",
       "code": "df[df['Count'] < 10000]",
-      "start": {
-        "line": 6,
-        "ch": 0
-      },
-      "end": {
-        "line": 6,
-        "ch": 23
+      "location": {
+        "start": {
+          "line": 6,
+          "ch": 0
+        },
+        "end": {
+          "line": 6,
+          "ch": 23
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 6,
-            "ch": 0
-          },
-          "end": {
-            "line": 6,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 6,
+              "ch": 0
+            },
+            "end": {
+              "line": 6,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[df['Count'] < 10000]",
-          "start": {
-            "line": 6,
-            "ch": 0
-          },
-          "end": {
-            "line": 6,
-            "ch": 23
+          "location": {
+            "start": {
+              "line": 6,
+              "ch": 0
+            },
+            "end": {
+              "line": 6,
+              "ch": 23
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsComparison",
             "code": "df['Count'] < 10000",
-            "start": {
-              "line": 6,
-              "ch": 3
-            },
-            "end": {
-              "line": 6,
-              "ch": 22
+            "location": {
+              "start": {
+                "line": 6,
+                "ch": 3
+              },
+              "end": {
+                "line": 6,
+                "ch": 22
+              }
             },
             "label_exprs": [
               "'Count'"
@@ -238,61 +274,71 @@
     {
       "type_": "VerbatimStatement",
       "code": "col = 'Name'",
-      "start": {
-        "line": 8,
-        "ch": 0
-      },
-      "end": {
-        "line": 8,
-        "ch": 12
+      "location": {
+        "start": {
+          "line": 8,
+          "ch": 0
+        },
+        "end": {
+          "line": 8,
+          "ch": 12
+        }
       }
     },
     {
       "type_": "ChainStatement",
       "code": "df[(df[col] > 10) | (df['Year'] >= 2020)]",
-      "start": {
-        "line": 9,
-        "ch": 0
-      },
-      "end": {
-        "line": 9,
-        "ch": 41
+      "location": {
+        "start": {
+          "line": 9,
+          "ch": 0
+        },
+        "end": {
+          "line": 9,
+          "ch": 41
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[(df[col] > 10) | (df['Year'] >= 2020)]",
-          "start": {
-            "line": 9,
-            "ch": 0
-          },
-          "end": {
-            "line": 9,
-            "ch": 41
+          "location": {
+            "start": {
+              "line": 9,
+              "ch": 0
+            },
+            "end": {
+              "line": 9,
+              "ch": 41
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsComparison",
             "code": "(df[col] > 10) | (df['Year'] >= 2020)",
-            "start": {
-              "line": 9,
-              "ch": 3
-            },
-            "end": {
-              "line": 9,
-              "ch": 40
+            "location": {
+              "start": {
+                "line": 9,
+                "ch": 3
+              },
+              "end": {
+                "line": 9,
+                "ch": 40
+              }
             },
             "label_exprs": [
               "col",
@@ -306,61 +352,71 @@
     {
       "type_": "VerbatimStatement",
       "code": "mask = df['Count'] > 10",
-      "start": {
-        "line": 11,
-        "ch": 0
-      },
-      "end": {
-        "line": 11,
-        "ch": 23
+      "location": {
+        "start": {
+          "line": 11,
+          "ch": 0
+        },
+        "end": {
+          "line": 11,
+          "ch": 23
+        }
       }
     },
     {
       "type_": "ChainStatement",
       "code": "df[mask]",
-      "start": {
-        "line": 12,
-        "ch": 0
-      },
-      "end": {
-        "line": 12,
-        "ch": 8
+      "location": {
+        "start": {
+          "line": 12,
+          "ch": 0
+        },
+        "end": {
+          "line": 12,
+          "ch": 8
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 12,
-            "ch": 0
-          },
-          "end": {
-            "line": 12,
-            "ch": 2
+          "location": {
+            "start": {
+              "line": 12,
+              "ch": 0
+            },
+            "end": {
+              "line": 12,
+              "ch": 2
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df[mask]",
-          "start": {
-            "line": 12,
-            "ch": 0
-          },
-          "end": {
-            "line": 12,
-            "ch": 8
+          "location": {
+            "start": {
+              "line": 12,
+              "ch": 0
+            },
+            "end": {
+              "line": 12,
+              "ch": 8
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsEval",
             "code": "mask",
-            "start": {
-              "line": 12,
-              "ch": 3
-            },
-            "end": {
-              "line": 12,
-              "ch": 7
+            "location": {
+              "start": {
+                "line": 12,
+                "ch": 3
+              },
+              "end": {
+                "line": 12,
+                "ch": 7
+              }
             },
             "expr": "mask"
           },
@@ -371,49 +427,57 @@
     {
       "type_": "ChainStatement",
       "code": "(df\n .iloc[2:5]\n .loc[:, df['tricky'] == 'to parse']\n)",
-      "start": {
-        "line": 14,
-        "ch": 0
-      },
-      "end": {
-        "line": 17,
-        "ch": 1
+      "location": {
+        "start": {
+          "line": 14,
+          "ch": 0
+        },
+        "end": {
+          "line": 17,
+          "ch": 1
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 14,
-            "ch": 1
-          },
-          "end": {
-            "line": 14,
-            "ch": 3
+          "location": {
+            "start": {
+              "line": 14,
+              "ch": 1
+            },
+            "end": {
+              "line": 14,
+              "ch": 3
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df\n .iloc[2:5]",
-          "start": {
-            "line": 14,
-            "ch": 1
-          },
-          "end": {
-            "line": 15,
-            "ch": 11
+          "location": {
+            "start": {
+              "line": 14,
+              "ch": 1
+            },
+            "end": {
+              "line": 15,
+              "ch": 11
+            }
           },
           "slicer": "iloc",
           "slice1": {
             "type_": "SubsSlice",
             "code": "2:5",
-            "start": {
-              "line": 15,
-              "ch": 7
-            },
-            "end": {
-              "line": 15,
-              "ch": 10
+            "location": {
+              "start": {
+                "line": 15,
+                "ch": 7
+              },
+              "end": {
+                "line": 15,
+                "ch": 10
+              }
             }
           },
           "slice2": null
@@ -421,37 +485,43 @@
         {
           "type_": "Subscript",
           "code": "(df\n .iloc[2:5]\n .loc[:, df['tricky'] == 'to parse']\n)",
-          "start": {
-            "line": 14,
-            "ch": 1
-          },
-          "end": {
-            "line": 16,
-            "ch": 36
+          "location": {
+            "start": {
+              "line": 14,
+              "ch": 1
+            },
+            "end": {
+              "line": 16,
+              "ch": 36
+            }
           },
           "slicer": "loc",
           "slice1": {
             "type_": "SubsSlice",
             "code": ":",
-            "start": {
-              "line": 16,
-              "ch": 6
-            },
-            "end": {
-              "line": 16,
-              "ch": 7
+            "location": {
+              "start": {
+                "line": 16,
+                "ch": 6
+              },
+              "end": {
+                "line": 16,
+                "ch": 7
+              }
             }
           },
           "slice2": {
             "type_": "SubsComparison",
             "code": "df['tricky'] == 'to parse'",
-            "start": {
-              "line": 16,
-              "ch": 9
-            },
-            "end": {
-              "line": 16,
-              "ch": 35
+            "location": {
+              "start": {
+                "line": 16,
+                "ch": 9
+              },
+              "end": {
+                "line": 16,
+                "ch": 35
+              }
             },
             "label_exprs": [
               "'tricky'"
@@ -463,49 +533,57 @@
     {
       "type_": "ChainStatement",
       "code": "(df\n [2:5]\n [df['also'] == 'tricky']\n)",
-      "start": {
-        "line": 19,
-        "ch": 0
-      },
-      "end": {
-        "line": 22,
-        "ch": 1
+      "location": {
+        "start": {
+          "line": 19,
+          "ch": 0
+        },
+        "end": {
+          "line": 22,
+          "ch": 1
+        }
       },
       "chain": [
         {
           "type_": "StartOfChain",
           "code": "df",
-          "start": {
-            "line": 19,
-            "ch": 1
-          },
-          "end": {
-            "line": 19,
-            "ch": 3
+          "location": {
+            "start": {
+              "line": 19,
+              "ch": 1
+            },
+            "end": {
+              "line": 19,
+              "ch": 3
+            }
           }
         },
         {
           "type_": "Subscript",
           "code": "df\n [2:5]",
-          "start": {
-            "line": 19,
-            "ch": 1
-          },
-          "end": {
-            "line": 20,
-            "ch": 6
+          "location": {
+            "start": {
+              "line": 19,
+              "ch": 1
+            },
+            "end": {
+              "line": 20,
+              "ch": 6
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsSlice",
             "code": "2:5",
-            "start": {
-              "line": 20,
-              "ch": 2
-            },
-            "end": {
-              "line": 20,
-              "ch": 5
+            "location": {
+              "start": {
+                "line": 20,
+                "ch": 2
+              },
+              "end": {
+                "line": 20,
+                "ch": 5
+              }
             }
           },
           "slice2": null
@@ -513,25 +591,29 @@
         {
           "type_": "Subscript",
           "code": "(df\n [2:5]\n [df['also'] == 'tricky']\n)",
-          "start": {
-            "line": 19,
-            "ch": 1
-          },
-          "end": {
-            "line": 21,
-            "ch": 25
+          "location": {
+            "start": {
+              "line": 19,
+              "ch": 1
+            },
+            "end": {
+              "line": 21,
+              "ch": 25
+            }
           },
           "slicer": null,
           "slice1": {
             "type_": "SubsComparison",
             "code": "df['also'] == 'tricky'",
-            "start": {
-              "line": 21,
-              "ch": 2
-            },
-            "end": {
-              "line": 21,
-              "ch": 24
+            "location": {
+              "start": {
+                "line": 21,
+                "ch": 2
+              },
+              "end": {
+                "line": 21,
+                "ch": 24
+              }
             },
             "label_exprs": [
               "'also'"

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -15,7 +15,10 @@ import pandas as pd
 from pandas.core.groupby.generic import (DataFrameGroupBy, SeriesGroupBy)
 from pandas.core.groupby.groupby import GroupBy
 
-from .diagram import Label, Labels
+# technically dataframe labels can be all sorts of things...
+# TODO: handle other index dtypes
+Label = t.Union[int, str]
+Labels = t.Union[t.List[int], t.List[str]]
 
 HasIndex = t.Union[pd.DataFrame, pd.Series]
 
@@ -38,6 +41,9 @@ class CodePosition:
     def __lt__(self, other: CodePosition):
         return self.line < other.line or self.ch < other.ch
 
+    def __gt__(self, other: CodePosition):
+        return self.line > other.line or self.ch > other.ch
+
 
 @dataclasses.dataclass
 class CodeRange:
@@ -52,13 +58,23 @@ class CodeRange:
 
     def __sub__(self, other: CodeRange):
         '''
-        the range within this CodeRange that doesn't overlap with other
+        a range within this CodeRange that doesn't overlap with other. similar
+        to set difference. assumes other isn't entirely contained within self,
+        and vice versa
         '''
+        # non-overlapping
         if self.end < other.start or other.end < self.start:
             return self
-        new_start = other.end if self.start < other.end else self.start
-        new_end = self.end if self.end < other.end else other.end
-        return CodeRange(new_start, new_end)
+
+        # cut off left tail, common case
+        if self.end > other.end:
+            return CodeRange(other.end, self.end)
+
+        # cut off right tail
+        if self.start < other.start:
+            return CodeRange(self.start, other.start)
+
+        return self
 
     def __mod__(self, pos: CodePosition):
         '''self % pos is the range relative to the starting line of pos'''

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -1,6 +1,8 @@
 '''
 utilities
 '''
+from __future__ import annotations
+import dataclasses
 import io
 import base64
 import gzip
@@ -18,6 +20,52 @@ from .diagram import Label, Labels
 HasIndex = t.Union[pd.DataFrame, pd.Series]
 
 Groups = t.Dict[t.Union[str, tuple], pd.Index]
+
+
+@dataclasses.dataclass
+class CodePosition:
+    '''
+    points to a location within the original code string. both lines and
+    columns are 0-indexed
+    '''
+    line: int
+    ch: int
+
+    def __mod__(self, other: CodePosition):
+        '''self % other is the position relative to other.line'''
+        return CodePosition(self.line - other.line, self.ch)
+
+    def __lt__(self, other: CodePosition):
+        return self.line < other.line or self.ch < other.ch
+
+
+@dataclasses.dataclass
+class CodeRange:
+    '''
+    points to a code range within the original code string. both lines and
+    columns are 0-indexed.
+
+    these are used to highlight code fragments in the frontend
+    '''
+    start: CodePosition
+    end: CodePosition
+
+    def __sub__(self, other: CodeRange):
+        '''
+        the range within this CodeRange that doesn't overlap with other
+        '''
+        if self.end < other.start or other.end < self.start:
+            return self
+        new_start = other.end if self.start < other.end else self.start
+        new_end = self.end if self.end < other.end else other.end
+        return CodeRange(new_start, new_end)
+
+    def __mod__(self, pos: CodePosition):
+        '''self % pos is the range relative to the starting line of pos'''
+        return CodeRange(self.start % pos, self.end % pos)
+
+
+NULL_LOC = CodeRange(CodePosition(-999, -999), CodePosition(-999, -999))
 
 IndexPair = t.Tuple[Label, Label]
 


### PR DESCRIPTION
i mark each step with the fragment of code that we ran. fragments are a range within a code string (right-exclusive).

for example, for:

```python
(dogs
 .groupby('size')
 ['food_cost']
 .mean()
)
```

i produce:

https://github.com/SamLau95/pandas_tutor/blob/21728ae9da7622398b18662e484745593c043b6f/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden#L4-L14

https://github.com/SamLau95/pandas_tutor/blob/21728ae9da7622398b18662e484745593c043b6f/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden#L202-L213

https://github.com/SamLau95/pandas_tutor/blob/21728ae9da7622398b18662e484745593c043b6f/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden#L380-L391