### PR TITLE
fix locations of nodes

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -79,12 +79,12 @@ class ErrorOutput:
     type: str = field(default='ErrorOutput', init=False, repr=False)
     code_step: str
     message: str
-    location: CodePosition
 
 
 @dataclasses.dataclass
 class SyntaxErrorOutput(ErrorOutput):
     type: str = field(default='SyntaxErrorOutput', init=False, repr=False)
+    location: CodePosition
 
     @classmethod
     def from_parse_syntax_error(cls, err: ParseSyntaxError):
@@ -96,6 +96,7 @@ class SyntaxErrorOutput(ErrorOutput):
 @dataclasses.dataclass
 class RuntimeErrorOutput(ErrorOutput):
     type: str = field(default='RuntimeErrorOutput', init=False, repr=False)
+    fragment: CodeRange
 
     @classmethod
     def from_runtime_error_result(cls, result: RuntimeErrorResult):
@@ -104,7 +105,7 @@ class RuntimeErrorOutput(ErrorOutput):
         message = list(tb.format_exception_only())[-1]
         return cls(code_step=result.step.code,
                    message=message,
-                   location=result.fragment.start)
+                   fragment=result.fragment)
 
 
 @dataclasses.dataclass

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -198,7 +198,7 @@ class PandasParser(m.MatcherDecoratableVisitor):
         if self.current is not None and len(self.current.chain) > 1:
             last = self.current.chain[-1]
             if isinstance(last, GroupByCall):
-                node = self.make_node(AggCall, cst_node)
+                node = self.make_call_node(AggCall, cst_node)
                 self.current.chain.append(node)
                 return
 
@@ -213,7 +213,7 @@ class PandasParser(m.MatcherDecoratableVisitor):
         assert self.current is not None, (
             'tried to call fallback when not in a chain!')
         fn_name = cst_node.func.attr.value
-        node = self.make_node(PassThroughCall, cst_node, fn_name=fn_name)
+        node = self.make_call_node(PassThroughCall, cst_node, fn_name=fn_name)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -234,10 +234,10 @@ class PandasParser(m.MatcherDecoratableVisitor):
         axis = (make_axis(self.code_for(axis_arg.value))
                 if axis_arg is not None else 'index')
 
-        node = self.make_node(SortValuesCall,
-                              cst_node,
-                              label_expr=label_expr,
-                              axis=axis)
+        node = self.make_call_node(SortValuesCall,
+                                   cst_node,
+                                   label_expr=label_expr,
+                                   axis=axis)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -264,10 +264,10 @@ class PandasParser(m.MatcherDecoratableVisitor):
             self.fallback_call(cst_node)
             return
 
-        node = self.make_node(RenameCall,
-                              cst_node,
-                              mapping_expr=self.code_for(mapper.value),
-                              axis=axis)
+        node = self.make_call_node(RenameCall,
+                                   cst_node,
+                                   mapping_expr=self.code_for(mapper.value),
+                                   axis=axis)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -276,8 +276,8 @@ class PandasParser(m.MatcherDecoratableVisitor):
         assert self.current is not None, (
             'tried to call make_head_or_tail when not in a chain!')
         name = fn_name(cst_node)
-        node = self.make_node(HeadCall if name == 'head' else TailCall,
-                              cst_node)
+        node = self.make_call_node(HeadCall if name == 'head' else TailCall,
+                                   cst_node)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -291,7 +291,7 @@ class PandasParser(m.MatcherDecoratableVisitor):
         axis = 'index'  # default
         if axis_arg is not None:
             axis = make_axis(self.code_for(axis_arg.value))
-        node = self.make_node(ApplyCall, cst_node, axis=axis)
+        node = self.make_call_node(ApplyCall, cst_node, axis=axis)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -305,9 +305,9 @@ class PandasParser(m.MatcherDecoratableVisitor):
             if arg.keyword is not None
         ]
 
-        node = self.make_node(AssignCall,
-                              cst_node,
-                              new_col_labels=new_col_labels)
+        node = self.make_call_node(AssignCall,
+                                   cst_node,
+                                   new_col_labels=new_col_labels)
         self.current.chain.append(node)
 
     @m.call_if_inside(is_chain_stmt)
@@ -326,7 +326,7 @@ class PandasParser(m.MatcherDecoratableVisitor):
         axis = (make_axis(self.code_for(axis_arg.value))
                 if axis_arg is not None else 'index')
 
-        node = self.make_node(GroupByCall, cst_node, axis=axis)
+        node = self.make_call_node(GroupByCall, cst_node, axis=axis)
         self.current.chain.append(node)
 
     ###########################################################################
@@ -361,15 +361,16 @@ class PandasParser(m.MatcherDecoratableVisitor):
     @m.call_if_inside(is_chain_stmt)
     @m.call_if_not_inside(m.SubscriptElement() | m.Arg())
     @m.leave(m.Subscript())
-    def make_subscript(self, cst_node):
+    def make_subscript(self, cst_node: cst.Subscript):
         assert self.current is not None, (
             'called make_subscript when not in a chain!')
         # HACK: limit subscript parsing depth to 1
         assert self.slice_depth == 0, (
             'called make_subscript in a nested subscript')
 
-        slicer = (cst_node.value.attr.value if m.matches(
-            cst_node, is_loc_iloc) else None)
+        slicer: t.Optional[str] = None
+        if m.matches(cst_node, is_loc_iloc):
+            slicer = t.cast(cst.Attribute, cst_node.value).attr.value
 
         n_slices = len(self.slices)
         slice1 = None
@@ -385,8 +386,17 @@ class PandasParser(m.MatcherDecoratableVisitor):
                   f'{self.slices}\n')
             # TODO: have a 'passthrough slice'
 
+        # from dogs["breed"], get location of ["breed"]
+        location = (self.location(cst_node.lbracket)
+                    | self.location(cst_node.rbracket))
+        # if we have a slicer, then we want the '.loc' too
+        if slicer is not None:
+            location = location | self.location(
+                t.cast(cst.Attribute, cst_node.value).dot)
+
         node = self.make_node(Subscript,
                               cst_node,
+                              location=location,
                               slicer=slicer,
                               slice1=slice1,
                               slice2=slice2)
@@ -470,10 +480,28 @@ class PandasParser(m.MatcherDecoratableVisitor):
         end = CodePosition(line=meta.end.line - 1, ch=meta.end.column)
         return CodeRange(start, end)
 
-    def make_node(self, cls: t.Type[T], cst_node: cst.CSTNode, **kwargs) -> T:
+    def make_node(self,
+                  cls: t.Type[T],
+                  cst_node: cst.CSTNode,
+                  location=None,
+                  **kwargs) -> T:
         code = self.code_for(cst_node)
-        location = self.location(cst_node)
+        if location is None:
+            location = self.location(cst_node)
         return cls(code=code, location=location, **kwargs)  # type: ignore
+
+    def make_call_node(self, cls: t.Type[T], cst_node: cst.Call,
+                       **kwargs) -> T:
+        '''
+        for calls in chain like df.apply(), the location of the call is the
+        dot + everything after
+        '''
+        func = t.cast(cst.Attribute, cst_node.func)
+        dot = self.location(func.dot)
+        entire_expr = self.location(cst_node)
+        location = CodeRange(dot.start, entire_expr.end)
+
+        return self.make_node(cls, cst_node, location=location, **kwargs)
 
 
 whitespace = (m.Comment() | m.EmptyLine() | m.Newline()

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -116,11 +116,10 @@ def run(root: ParseResult) -> t.List[EvalResult]:
             ]
 
     relative_to = last_expr.location.start
-    last_location = NULL_LOC
     last_val: t.Any = None
     eval_results: t.List[EvalResult] = []
     for step in last_expr.chain:
-        fragment = (step.location - last_location) % relative_to
+        fragment = step.location % relative_to
 
         try:
             # wrap individual steps in parens before eval since subexpressions
@@ -141,8 +140,14 @@ def run(root: ParseResult) -> t.List[EvalResult]:
         result = make_result(step, fragment, args, val, last_val)
         eval_results.append(result)
         last_val = val
-        last_location = step.location
 
+    # HACK: hard-code all step code strings to the entire statement's code
+    # string to make fragment positions work. the code string for individual
+    # function calls omits the whitespace that the fragment positions already
+    # take into account.
+    # https://github.com/SamLau95/pandas_tutor/issues/42
+    for result in eval_results:
+        result.step.code = last_expr.code
     return eval_results
 
 

--- a/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
@@ -6,8 +6,8 @@
       "code_step": "(dogs\n .apply(lambda x: x * 2)\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,

--- a/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "Subscript",
-      "code_step": "dogs['breed']",
+      "code_step": "(dogs['breed']\n .apply(len)\n)",
       "fragment": {
         "start": {
           "line": 0,
@@ -121,8 +121,8 @@
       "code_step": "(dogs['breed']\n .apply(len)\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 14
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,

--- a/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
@@ -6,8 +6,8 @@
       "code_step": "(dogs\n .assign(daily=lambda df: df['food_cost'] * 30)\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,

--- a/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
@@ -6,8 +6,8 @@
       "code_step": "(dogs\n .assign(test='hello world')\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,

--- a/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
@@ -6,8 +6,8 @@
       "code_step": "(dogs\n .assign(daily=dogs['food_cost'] * 30)\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_01.py.golden
@@ -3,11 +3,17 @@
   "explanation": [
     {
       "type": "RuntimeErrorInChain",
-      "code_step": "dogs\n .loc[:, ['not_a_column']]",
+      "code_step": "(dogs\n .loc[:, ['not_a_column']]\n .sort_values('kids')\n)",
       "message": "KeyError: \"None of [Index(['not_a_column'], dtype='object')] are in the [columns]\"\n",
-      "location": {
-        "line": 0,
-        "ch": 5
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 26
+        }
       }
     }
   ]

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
@@ -3,11 +3,11 @@
   "explanation": [
     {
       "type": "SortValuesCall",
-      "code_step": "dogs\n .sort_values('kids')",
+      "code_step": "(dogs\n .sort_values('kids')\n .loc[:, ['not_a_column']]\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,
@@ -253,9 +253,15 @@
       "type": "RuntimeErrorInChain",
       "code_step": "(dogs\n .sort_values('kids')\n .loc[:, ['not_a_column']]\n)",
       "message": "KeyError: \"None of [Index(['not_a_column'], dtype='object')] are in the [columns]\"\n",
-      "location": {
-        "line": 1,
-        "ch": 21
+      "fragment": {
+        "start": {
+          "line": 2,
+          "ch": 1
+        },
+        "end": {
+          "line": 2,
+          "ch": 26
+        }
       }
     }
   ]

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_setup.py.golden
@@ -5,9 +5,15 @@
       "type": "RuntimeErrorInSetup",
       "code_step": "dogs = pd.read_csv(io.StringIO(some_random_var_name))",
       "message": "NameError: name 'some_random_var_name' is not defined\n",
-      "location": {
-        "line": 14,
-        "ch": 0
+      "fragment": {
+        "start": {
+          "line": 14,
+          "ch": 0
+        },
+        "end": {
+          "line": 14,
+          "ch": 53
+        }
       }
     }
   ]

--- a/pandas_tutor/tests/e2e_golden/fragment_test_01.py
+++ b/pandas_tutor/tests/e2e_golden/fragment_test_01.py
@@ -1,0 +1,11 @@
+# tests that fragments point to the right parts of the code
+
+import pandas as pd
+import io
+csv = "breed,grooming,food_cost,kids,size"
+dogs = pd.read_csv(io.StringIO(csv))
+
+(    dogs  ["breed"] # <-- look at leading spaces here
+ .apply(len) # another comment test
+   .rename('test'   )       # test
+)

--- a/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
@@ -1,0 +1,100 @@
+{
+  "code": "# tests that fragments point to the right parts of the code\n\nimport pandas as pd\nimport io\ncsv = \"breed,grooming,food_cost,kids,size\"\ndogs = pd.read_csv(io.StringIO(csv))\n\n(    dogs  [\"breed\"] # <-- look at leading spaces here\n .apply(len) # another comment test\n   .rename('test'   )       # test\n)\n",
+  "explanation": [
+    {
+      "type": "Subscript",
+      "code_step": "(    dogs  [\"breed\"] # <-- look at leading spaces here\n .apply(len) # another comment test\n   .rename('test'   )       # test\n)",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 11
+        },
+        "end": {
+          "line": 0,
+          "ch": 20
+        }
+      },
+      "mapping": [
+        {
+          "select": "column",
+          "anchor": "lhs",
+          "label": "breed",
+          "illustrate": "highlight"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [],
+          "data": []
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [],
+          "data": []
+        }
+      }
+    },
+    {
+      "type": "ApplyCall",
+      "code_step": "(    dogs  [\"breed\"] # <-- look at leading spaces here\n .apply(len) # another comment test\n   .rename('test'   )       # test\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 12
+        }
+      },
+      "mapping": [],
+      "data_frame": {
+        "lhs": {
+          "type": "Series",
+          "row_labels": [],
+          "data": []
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [],
+          "data": []
+        }
+      }
+    },
+    {
+      "type": "RenameCall",
+      "code_step": "(    dogs  [\"breed\"] # <-- look at leading spaces here\n .apply(len) # another comment test\n   .rename('test'   )       # test\n)",
+      "fragment": {
+        "start": {
+          "line": 2,
+          "ch": 3
+        },
+        "end": {
+          "line": 2,
+          "ch": 21
+        }
+      },
+      "mapping": [],
+      "data_frame": {
+        "lhs": {
+          "type": "Series",
+          "row_labels": [],
+          "data": []
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [],
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
@@ -3,11 +3,11 @@
   "explanation": [
     {
       "type": "GroupByCall",
-      "code_step": "dogs\n .groupby('size')",
+      "code_step": "(dogs\n .groupby('size')\n ['food_cost']\n .mean()\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,
@@ -202,11 +202,11 @@
     },
     {
       "type": "Subscript",
-      "code_step": "dogs\n .groupby('size')\n ['food_cost']",
+      "code_step": "(dogs\n .groupby('size')\n ['food_cost']\n .mean()\n)",
       "fragment": {
         "start": {
-          "line": 1,
-          "ch": 17
+          "line": 2,
+          "ch": 1
         },
         "end": {
           "line": 2,
@@ -383,8 +383,8 @@
       "code_step": "(dogs\n .groupby('size')\n ['food_cost']\n .mean()\n)",
       "fragment": {
         "start": {
-          "line": 2,
-          "ch": 14
+          "line": 3,
+          "ch": 1
         },
         "end": {
           "line": 3,

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
@@ -3,11 +3,11 @@
   "explanation": [
     {
       "type": "GroupByCall",
-      "code_step": "dogs\n .groupby('grooming')",
+      "code_step": "(dogs\n .groupby('grooming')\n .max()\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,
@@ -198,8 +198,8 @@
       "code_step": "(dogs\n .groupby('grooming')\n .max()\n)",
       "fragment": {
         "start": {
-          "line": 1,
-          "ch": 21
+          "line": 2,
+          "ch": 1
         },
         "end": {
           "line": 2,

--- a/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
@@ -3,11 +3,11 @@
   "explanation": [
     {
       "type": "GroupByCall",
-      "code_step": "dogs\n .groupby('grooming')",
+      "code_step": "(dogs\n .groupby('grooming')\n .agg('mean')\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,
@@ -198,8 +198,8 @@
       "code_step": "(dogs\n .groupby('grooming')\n .agg('mean')\n)",
       "fragment": {
         "start": {
-          "line": 1,
-          "ch": 21
+          "line": 2,
+          "ch": 1
         },
         "end": {
           "line": 2,

--- a/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "GroupByCall",
-      "code_step": "pm.groupby(months)",
+      "code_step": "pm.groupby(months).mean()",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "SortValuesCall",
-      "code_step": "dogs.sort_values('kids')",
+      "code_step": "dogs.sort_values('kids').iloc[0:6]",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "SortValuesCall",
-      "code_step": "dogs.sort_values('kids')",
+      "code_step": "dogs.sort_values('kids').loc[0:6]",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/plot_end_of_chain.py.golden
+++ b/pandas_tutor/tests/e2e_golden/plot_end_of_chain.py.golden
@@ -3,11 +3,11 @@
   "explanation": [
     {
       "type": "GroupByCall",
-      "code_step": "dogs\n .groupby('size')",
+      "code_step": "(dogs\n .groupby('size')\n .mean()\n .plot(kind='bar')\n)",
       "fragment": {
         "start": {
-          "line": 0,
-          "ch": 5
+          "line": 1,
+          "ch": 1
         },
         "end": {
           "line": 1,
@@ -202,11 +202,11 @@
     },
     {
       "type": "AggCall",
-      "code_step": "dogs\n .groupby('size')\n .mean()",
+      "code_step": "(dogs\n .groupby('size')\n .mean()\n .plot(kind='bar')\n)",
       "fragment": {
         "start": {
-          "line": 1,
-          "ch": 17
+          "line": 2,
+          "ch": 1
         },
         "end": {
           "line": 2,
@@ -434,8 +434,8 @@
       "code_step": "(dogs\n .groupby('size')\n .mean()\n .plot(kind='bar')\n)",
       "fragment": {
         "start": {
-          "line": 2,
-          "ch": 8
+          "line": 3,
+          "ch": 1
         },
         "end": {
           "line": 3,

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "Subscript",
-      "code_step": "dogs['food_cost']",
+      "code_step": "dogs['food_cost'].mean()",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "Subscript",
-      "code_step": "dogs['breed']",
+      "code_step": "dogs['breed'].to_frame()",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
@@ -3,7 +3,7 @@
   "explanation": [
     {
       "type": "SortValuesCall",
-      "code_step": "df.sort_values('Name')",
+      "code_step": "df.sort_values('Name').sort_values('Count')",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/parse_golden/basic_chain.py.golden
+++ b/pandas_tutor/tests/parse_golden/basic_chain.py.golden
@@ -45,7 +45,7 @@
           "code": "df\n .sort_values('Name')",
           "location": {
             "start": {
-              "line": 0,
+              "line": 1,
               "ch": 1
             },
             "end": {
@@ -61,7 +61,7 @@
           "code": "(df\n .sort_values('Name')\n .loc[:, 'Count']\n)",
           "location": {
             "start": {
-              "line": 0,
+              "line": 2,
               "ch": 1
             },
             "end": {

--- a/pandas_tutor/tests/parse_golden/filter_01.py.golden
+++ b/pandas_tutor/tests/parse_golden/filter_01.py.golden
@@ -74,7 +74,7 @@
           "location": {
             "start": {
               "line": 9,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 9,

--- a/pandas_tutor/tests/parse_golden/loc_one_val_01.py.golden
+++ b/pandas_tutor/tests/parse_golden/loc_one_val_01.py.golden
@@ -74,7 +74,7 @@
           "location": {
             "start": {
               "line": 9,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 9,

--- a/pandas_tutor/tests/parse_golden/sort_value_args.py.golden
+++ b/pandas_tutor/tests/parse_golden/sort_value_args.py.golden
@@ -46,7 +46,7 @@
           "location": {
             "start": {
               "line": 5,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 5,
@@ -106,7 +106,7 @@
           "location": {
             "start": {
               "line": 8,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 8,
@@ -152,7 +152,7 @@
           "location": {
             "start": {
               "line": 10,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 10,
@@ -198,7 +198,7 @@
           "location": {
             "start": {
               "line": 12,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 12,

--- a/pandas_tutor/tests/parse_golden/subscript_args.py.golden
+++ b/pandas_tutor/tests/parse_golden/subscript_args.py.golden
@@ -46,7 +46,7 @@
           "location": {
             "start": {
               "line": 1,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 1,
@@ -120,7 +120,7 @@
           "location": {
             "start": {
               "line": 3,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 3,
@@ -181,7 +181,7 @@
           "location": {
             "start": {
               "line": 4,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 4,
@@ -242,7 +242,7 @@
           "location": {
             "start": {
               "line": 6,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 6,
@@ -319,7 +319,7 @@
           "location": {
             "start": {
               "line": 9,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 9,
@@ -397,7 +397,7 @@
           "location": {
             "start": {
               "line": 12,
-              "ch": 0
+              "ch": 2
             },
             "end": {
               "line": 12,
@@ -457,7 +457,7 @@
           "code": "df\n .iloc[2:5]",
           "location": {
             "start": {
-              "line": 14,
+              "line": 15,
               "ch": 1
             },
             "end": {
@@ -487,7 +487,7 @@
           "code": "(df\n .iloc[2:5]\n .loc[:, df['tricky'] == 'to parse']\n)",
           "location": {
             "start": {
-              "line": 14,
+              "line": 16,
               "ch": 1
             },
             "end": {
@@ -563,7 +563,7 @@
           "code": "df\n [2:5]",
           "location": {
             "start": {
-              "line": 19,
+              "line": 20,
               "ch": 1
             },
             "end": {
@@ -593,7 +593,7 @@
           "code": "(df\n [2:5]\n [df['also'] == 'tricky']\n)",
           "location": {
             "start": {
-              "line": 19,
+              "line": 21,
               "ch": 1
             },
             "end": {

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -36,10 +36,12 @@ class CodePosition:
         return CodePosition(self.line - other.line, self.ch)
 
     def __lt__(self, other: CodePosition):
-        return self.line < other.line or self.ch < other.ch
+        return (self.line < other.line
+                if self.line != other.line else self.ch < other.ch)
 
     def __gt__(self, other: CodePosition):
-        return self.line > other.line or self.ch > other.ch
+        return (self.line > other.line
+                if self.line != other.line else self.ch > other.ch)
 
 
 @dataclasses.dataclass
@@ -56,8 +58,7 @@ class CodeRange:
     def __sub__(self, other: CodeRange):
         '''
         a range within this CodeRange that doesn't overlap with other. similar
-        to set difference. assumes other isn't entirely contained within self,
-        and vice versa
+        to set difference. assumes the CodeRanges only partially overlap
         '''
         # non-overlapping
         if self.end < other.start or other.end < self.start:
@@ -72,6 +73,14 @@ class CodeRange:
             return CodeRange(self.start, other.start)
 
         return self
+
+    def __or__(self, other: CodeRange):
+        '''
+        minimum CodeRange that contains both self and other
+        '''
+        return CodeRange(
+            start=self.start if self.start < other.start else other.start,
+            end=self.end if self.end > other.end else other.end)
 
     def __mod__(self, pos: CodePosition):
         '''self % pos is the range relative to the starting line of pos'''


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/42

before, we weren't parsing fragment locations with whitespace and comments properly, as in:

https://github.com/SamLau95/pandas_tutor/blob/68ce400943a8439e209ec318ab426c863b10608f/pandas_tutor/tests/e2e_golden/fragment_test_01.py#L8-L11

now, these positions are parsed properly:

https://github.com/SamLau95/pandas_tutor/blob/68ce400943a8439e209ec318ab426c863b10608f/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden#L5-L16

https://github.com/SamLau95/pandas_tutor/blob/68ce400943a8439e209ec318ab426c863b10608f/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden#L46-L57

https://github.com/SamLau95/pandas_tutor/blob/68ce400943a8439e209ec318ab426c863b10608f/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden#L73-L84

we also stick the entire code snippet into `code_step` to make highlighting offsets work. it's redundant, but not by too much.