### PR TITLE
draw arrows from dataframes to series

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -4,6 +4,7 @@ creates mark specs. here's where the magic happens!
 import typing as t
 
 import pandas as pd
+from pandas.core.groupby.generic import DataFrameGroupBy
 
 from . import util
 from .diagram import Highlight, Mark, Outline, Selection, TablePos
@@ -171,7 +172,8 @@ def mark_for_agg(step: AggCall, before: EvalResult,
 # df.groupby('Sex')[['Count']]
 def mark_for_subscript(step: Subscript, before: EvalResult,
                        after: EvalResult) -> t.List[Mark]:
-    if (isinstance(before, DFResult) and isinstance(after, SeriesResult)):
+    if (isinstance(before, (DFResult, GroupbyResult))
+            and isinstance(after, (SeriesResult, SeriesGroupbyResult))):
         return mark_for_subscript_to_series(step, before, after)
     elif not isinstance(before, (DFResult, GroupbyResult)):
         return []
@@ -182,10 +184,10 @@ def mark_for_subscript(step: Subscript, before: EvalResult,
     col_slice = step.slice2
     args = after.args
 
-    before_df = util.ungroup(before.val) if isinstance(
-        before, GroupbyResult) else before.val
-    after_df = util.ungroup(after.val) if isinstance(
-        after, GroupbyResult) else after.val
+    before_df = (util.ungroup(before.val)
+                 if isinstance(before, GroupbyResult) else before.val)
+    after_df = (util.ungroup(after.val)
+                if isinstance(after, GroupbyResult) else after.val)
     row_marks = diff_rows(before_df, after_df)
     col_marks = diff_cols(before_df, after_df)
 
@@ -202,8 +204,9 @@ def mark_for_subscript(step: Subscript, before: EvalResult,
     return [*col_marks, *row_marks]
 
 
-def mark_for_subscript_to_series(step: Subscript, before: EvalResult,
-                                 after: EvalResult) -> t.List[Mark]:
+def mark_for_subscript_to_series(
+        step: Subscript, before: t.Union[DFResult, GroupbyResult],
+        after: t.Union[SeriesResult, SeriesGroupbyResult]) -> t.List[Mark]:
     args = after.args
     # when the output is a series, just highlight the row/column used for
     # slicing, like the 'kids' in df['kids']
@@ -211,18 +214,41 @@ def mark_for_subscript_to_series(step: Subscript, before: EvalResult,
     # df['kids']
     if step.slicer is None:
         maybe_col = args.get('slice1_values')
-        if isinstance(maybe_col, (str, int)):
-            return make_highlights([maybe_col], 'column')
-    else:
-        # df.iloc[0]
-        maybe_row = args.get('slice1_values')
-        if isinstance(maybe_row, (str, int)):
-            return make_highlights([maybe_row], 'row')
+        if not isinstance(maybe_col, (str, int)):
+            return []
 
-        # df.iloc[:, 0]
-        maybe_col = args.get('slice2_values')
-        if isinstance(maybe_col, (str, int)):
-            return make_highlights([maybe_col], 'column')
+        highlights = make_highlights([maybe_col], 'column')
+        outlines = [
+            Outline(select='column', from_=lhs(maybe_col), to=rhs_series())
+        ]
+        return [*highlights, *outlines]
+
+    # df.iloc[0]
+    maybe_row = args.get('slice1_values')
+    if isinstance(maybe_row, (str, int)):
+        row = maybe_row
+        if step.slicer == 'iloc':
+            df = (util.ungroup(before.val) if isinstance(
+                before, GroupbyResult) else before.val)
+            row = df.index[row]
+
+        highlights = make_highlights([row], 'row')
+        outlines = [Outline(select='row', from_=lhs(row), to=rhs_series())]
+        return [*highlights, *outlines]
+
+    # df.iloc[:, 0]
+    maybe_col = args.get('slice2_values')
+    if isinstance(maybe_col, (str, int)):
+        col = maybe_col
+        if step.slicer == 'iloc':
+            df = (util.ungroup(before.val) if isinstance(
+                before, GroupbyResult) else before.val)
+            col = df.columns[col]
+        highlights = make_highlights([col], 'column')
+        outlines = [
+            Outline(select='column', from_=lhs(col), to=rhs_series())
+        ]
+        return [*highlights, *outlines]
 
     return []
 
@@ -296,3 +322,11 @@ def lhs(label):
 
 def rhs(label):
     return TablePos('rhs', label)
+
+
+def lhs_series():
+    return lhs('pandas.Series')
+
+
+def rhs_series():
+    return rhs('pandas.Series')

--- a/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
@@ -20,6 +20,18 @@
           "anchor": "lhs",
           "label": "breed",
           "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "breed"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
@@ -20,6 +20,18 @@
           "anchor": "lhs",
           "label": "breed",
           "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "breed"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
@@ -213,7 +213,26 @@
           "ch": 14
         }
       },
-      "mapping": [],
+      "mapping": [
+        {
+          "select": "column",
+          "anchor": "lhs",
+          "label": "food_cost",
+          "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "food_cost"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
+        }
+      ],
       "data_frame": {
         "lhs": {
           "type": "DataFrameGroupBy",

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs.iloc[:, 0])

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
@@ -1,31 +1,31 @@
 {
-  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\ndogs['food_cost'].mean()\n",
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\n(dogs.iloc[:, 0])\n",
   "explanation": [
     {
       "type": "Subscript",
-      "code_step": "dogs['food_cost'].mean()",
+      "code_step": "(dogs.iloc[:, 0])",
       "fragment": {
         "start": {
           "line": 0,
-          "ch": 4
+          "ch": 5
         },
         "end": {
           "line": 0,
-          "ch": 17
+          "ch": 16
         }
       },
       "mapping": [
         {
           "select": "column",
           "anchor": "lhs",
-          "label": "food_cost",
+          "label": "breed",
           "illustrate": "highlight"
         },
         {
           "select": "column",
           "from": {
             "anchor": "lhs",
-            "label": "food_cost"
+            "label": "breed"
           },
           "to": {
             "anchor": "rhs",
@@ -117,56 +117,14 @@
             6
           ],
           "data": [
-            466.0,
-            466.0,
-            324.0,
-            466.0,
-            324.0,
-            466.0,
-            466.0
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle",
+            "Golden Retriever",
+            "Yorkshire Terrier",
+            "Bulldog",
+            "Boxer"
           ]
-        }
-      }
-    },
-    {
-      "type": "PassThroughCall",
-      "code_step": "dogs['food_cost'].mean()",
-      "fragment": {
-        "start": {
-          "line": 0,
-          "ch": 17
-        },
-        "end": {
-          "line": 0,
-          "ch": 24
-        }
-      },
-      "mapping": [],
-      "data_frame": {
-        "lhs": {
-          "type": "Series",
-          "row_labels": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6
-          ],
-          "data": [
-            466.0,
-            466.0,
-            324.0,
-            466.0,
-            324.0,
-            466.0,
-            466.0
-          ]
-        },
-        "rhs": {
-          "type": "Unhandled",
-          "data": "425.42857142857144"
         }
       }
     }

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+dogs.set_index('breed').iloc[2]

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
@@ -1,0 +1,267 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\ndogs.set_index('breed').iloc[2]\n",
+  "explanation": [
+    {
+      "type": "PassThroughCall",
+      "code_step": "dogs.set_index('breed').iloc[2]",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 4
+        },
+        "end": {
+          "line": 0,
+          "ch": 23
+        }
+      },
+      "mapping": [],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "Beagle",
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "Golden Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "Yorkshire Terrier",
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "Bulldog",
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "Boxer",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle",
+            "Golden Retriever",
+            "Yorkshire Terrier",
+            "Bulldog",
+            "Boxer"
+          ],
+          "data": [
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "type": "Subscript",
+      "code_step": "dogs.set_index('breed').iloc[2]",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 23
+        },
+        "end": {
+          "line": 0,
+          "ch": 31
+        }
+      },
+      "mapping": [
+        {
+          "select": "row",
+          "anchor": "lhs",
+          "label": "Beagle",
+          "illustrate": "highlight"
+        },
+        {
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": "Beagle"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle",
+            "Golden Retriever",
+            "Yorkshire Terrier",
+            "Bulldog",
+            "Boxer"
+          ],
+          "data": [
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "data": [
+            "daily",
+            324.0,
+            "high",
+            "small"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
@@ -20,6 +20,18 @@
           "anchor": "lhs",
           "label": "breed",
           "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "breed"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
@@ -20,6 +20,18 @@
           "anchor": "lhs",
           "label": "food_cost",
           "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "food_cost"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -20,6 +20,18 @@
           "anchor": "lhs",
           "label": "breed",
           "illustrate": "highlight"
+        },
+        {
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "breed"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/43

before, we wouldn't draw arrows pointing to series:

<img width="715" alt="Screen Shot 2021-11-22 at 5 35 46 PM" src="https://user-images.githubusercontent.com/2468904/142959284-7fe5217d-3681-4507-84ed-778fab03429c.png">

now, we will:

https://github.com/SamLau95/pandas_tutor/blob/eeee3a4b38bfd57ed821103c8182af9571f6d318/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden#L24-L35

notice that `to.label` is `pandas.Series`. that's a special label that we're using to represent a series (since series objects don't have column labels).