### PR TITLE
catch and serialize indexing errors

### DIFF
--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -17,6 +17,7 @@ https://pythontutor.com/visualize.html#code=s%20%3D%20'hello%20world%20!!%20'%0A
 from __future__ import annotations
 
 import typing as t
+from warnings import warn
 
 import libcst as cst
 import libcst.matchers as m
@@ -384,9 +385,10 @@ class PandasParser(m.MatcherDecoratableVisitor):
         elif n_slices == 2:
             [slice1, slice2, *_] = self.slices
         else:
-            print(f'weird: parsed subscript with {n_slices} slices @\n'
-                  f'{self.code_for(cst_node)}\n'
-                  f'{self.slices}\n')
+            warn(f'weird: parsed subscript with {n_slices} slices @\n'
+                 f'{self.code_for(cst_node)}\n\n'
+                 f'self.slices:\n'
+                 f'{self.slices}\n')
             # TODO: have a 'passthrough slice'
 
         # from dogs["breed"], get location of ["breed"]
@@ -439,8 +441,8 @@ class PandasParser(m.MatcherDecoratableVisitor):
             f'called make_subs_comparison outside a comparison:'
             f'{self.code_for(cst_node)}')
         if len(self.comparison_labels) == 0:
-            print("couldn't parse labels out of comparison, falling back "
-                  "to eval slice")
+            warn("couldn't parse labels out of comparison, falling back "
+                 "to eval slice")
             node = self.fallback_slice(cst_node)
             self.slices.append(node)
             return

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import builtins
 import contextlib
 import dataclasses
-import io
 import sys
 import types
 import typing as t
@@ -24,11 +23,6 @@ from .parse_nodes import (AggCall, ChainStatement, ChainStep, CodeRange,
 Arg = t.Union[str, t.List[str]]
 
 Args = t.Dict[str, Arg]
-
-# errors that we care about showing to the user
-serializable_errors = (ArithmeticError, AttributeError, ImportError,
-                       LookupError, NameError, RuntimeError, TypeError,
-                       ValueError)
 
 
 @dataclasses.dataclass
@@ -83,13 +77,6 @@ class UnhandledResult(EvalResult):
 
 
 def run(root: ParseResult) -> t.List[EvalResult]:
-    if util.in_testing_env():
-        # toss out stdout and stderr to avoid cluttering test output.
-        buffer = io.StringIO()
-        with contextlib.redirect_stdout(buffer):
-            with contextlib.redirect_stderr(buffer):
-                return run_code(root)
-
     # since we send JSON to stdout, we'll send user code's stdout to stderr.
     with contextlib.redirect_stdout(sys.stderr):
         return run_code(root)
@@ -119,7 +106,7 @@ def run_code(root: ParseResult) -> t.List[EvalResult]:
     for stmt in setup_stmts:
         try:
             exec(stmt.code, user_globals)
-        except serializable_errors as error:
+        except Exception as error:
             step = EvalError.from_node(stmt)
             return [
                 RuntimeErrorResult(
@@ -141,7 +128,7 @@ def run_code(root: ParseResult) -> t.List[EvalResult]:
             # within a line can have newlines
             val = eval(f"({step.code})", user_globals)
             args = eval_args(step, user_globals)
-        except serializable_errors as error:
+        except Exception as error:
             step = EvalError.from_node(step)
             err_result = RuntimeErrorResult(
                 step=step,

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_01.py
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_01.py
@@ -1,0 +1,3 @@
+import pandas as pd
+s = pd.Series([3, -5, 7, 4], index=['a', 'b', 'c', 'd'])
+s.loc[1,3]

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_01.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_01.py.golden
@@ -1,0 +1,20 @@
+{
+  "code": "import pandas as pd\ns = pd.Series([3, -5, 7, 4], index=['a', 'b', 'c', 'd'])\ns.loc[1,3]\n",
+  "explanation": [
+    {
+      "type": "RuntimeErrorInChain",
+      "code_step": "s.loc[1,3]",
+      "message": "pandas.core.indexing.IndexingError: Too many indexers\n",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 1
+        },
+        "end": {
+          "line": 0,
+          "ch": 10
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_02.py
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_02.py
@@ -1,0 +1,9 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html
+import pandas as pd
+import numpy as np
+np.random.seed(0) # uncomment if you want deterministic outputs
+s = pd.Series([1, 3, 5, np.nan, 6, 8])
+dates = pd.date_range("20130101", periods=6)
+df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
+
+df.loc["2013-01-03":"2013-01-05", ["C", "B"], "foo"]

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_02.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_02.py.golden
@@ -1,0 +1,20 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html\nimport pandas as pd\nimport numpy as np\nnp.random.seed(0) # uncomment if you want deterministic outputs\ns = pd.Series([1, 3, 5, np.nan, 6, 8])\ndates = pd.date_range(\"20130101\", periods=6)\ndf = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list(\"ABCD\"))\n\ndf.loc[\"2013-01-03\":\"2013-01-05\", [\"C\", \"B\"], \"foo\"]\n",
+  "explanation": [
+    {
+      "type": "RuntimeErrorInChain",
+      "code_step": "df.loc[\"2013-01-03\":\"2013-01-05\", [\"C\", \"B\"], \"foo\"]",
+      "message": "pandas.core.indexing.IndexingError: Too many indexers\n",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 52
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_03.py
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_03.py
@@ -1,0 +1,9 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html
+import pandas as pd
+import numpy as np
+np.random.seed(0) # uncomment if you want deterministic outputs
+s = pd.Series([1, 3, 5, np.nan, 6, 8])
+dates = pd.date_range("20130101", periods=6)
+df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
+
+df.iloc[1, 2, 3, [1, 2, 4], [0, 2]]

--- a/pandas_tutor/tests/pg_wreck_it/crash_indexers_03.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_indexers_03.py.golden
@@ -1,0 +1,20 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html\nimport pandas as pd\nimport numpy as np\nnp.random.seed(0) # uncomment if you want deterministic outputs\ns = pd.Series([1, 3, 5, np.nan, 6, 8])\ndates = pd.date_range(\"20130101\", periods=6)\ndf = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list(\"ABCD\"))\n\ndf.iloc[1, 2, 3, [1, 2, 4], [0, 2]]\n",
+  "explanation": [
+    {
+      "type": "RuntimeErrorInChain",
+      "code_step": "df.iloc[1, 2, 3, [1, 2, 4], [0, 2]]",
+      "message": "pandas.core.indexing.IndexingError: Too many indexers\n",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 35
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/pg_wreck_it/parsing_warnings_01.py
+++ b/pandas_tutor/tests/pg_wreck_it/parsing_warnings_01.py
@@ -1,0 +1,28 @@
+# https://www.shanelynn.ie/pandas-iloc-loc-select-rows-and-columns-dataframe/
+import pandas as pd
+import io
+csv = """
+first_name,last_name,company_name,address,city,county,postal,phone1,phone2,email,web
+Aleshia,Tomkiewicz,Alan D Rosenburg Cpa Pc,14 Taylor St,St. Stephens Ward,Kent,CT2 7PP,01835-703597,01944-369967,atomkiewicz@hotmail.com,http://www.alandrosenburgcpapc.co.uk
+Evan,Zigomalas,Cap Gemini America,5 Binney St,Abbey Ward,Buckinghamshire,HP11 2AX,01937-864715,01714-737668,evan.zigomalas@gmail.com,http://www.capgeminiamerica.co.uk
+France,Andrade,"Elliott, John W Esq",8 Moor Place,East Southbourne and Tuckton W,Bournemouth,BH6 3BE,01347-368222,01935-821636,france.andrade@hotmail.com,http://www.elliottjohnwesq.co.uk
+Ulysses,Mcwalters,"Mcmahan, Ben L",505 Exeter Rd,Hawerby cum Beesby,Lincolnshire,DN36 5RP,01912-771311,01302-601380,ulysses@hotmail.com,http://www.mcmahanbenl.co.uk
+Tyisha,Veness,Champagne Room,5396 Forth Street,Greets Green and Lyng Ward,West Midlands,B70 9DT,01547-429341,01290-367248,tyisha.veness@hotmail.com,http://www.champagneroom.co.uk
+Eric,Rampy,"Thompson, Michael C Esq",9472 Lind St,Desborough,Northamptonshire,NN14 2GH,01969-886290,01545-817375,erampy@rampy.co.uk,http://www.thompsonmichaelcesq.co.uk
+Marg,Grasmick,Wrangle Hill Auto Auct & Slvg,7457 Cowl St #70,Bargate Ward,Southampton,SO14 3TY,01865-582516,01362-620532,marg@hotmail.com,http://www.wranglehillautoauctslvg.co.uk
+Laquita,Hisaw,In Communications Inc,20 Gloucester Pl #96,Chirton Ward,Tyne & Wear,NE29 7AD,01746-394243,01590-982428,laquita@yahoo.com,http://www.incommunicationsinc.co.uk
+Lura,Manzella,Bizerba Usa Inc,929 Augustine St,Staple Hill Ward,South Gloucestershire,BS16 4LL,01907-538509,01340-713951,lura@hotmail.com,http://www.bizerbausainc.co.uk
+Yuette,Klapec,Max Video,45 Bradfield St #166,Parwich,Derbyshire,DE6 1QN,01903-649460,01933-512513,yuette.klapec@klapec.co.uk,http://www.maxvideo.co.uk
+Fernanda,Writer,K & R Associates Inc,620 Northampton St,Wilmington,Kent,DA2 7PP,01630-202053,01687-879391,fernanda@writer.co.uk,http://www.krassociatesinc.co.uk
+Charlesetta,Erm,"Cain, John M Esq",5 Hygeia St,Loundsley Green Ward,Derbyshire,S40 4LY,01276-816806,01517-624517,charlesetta_erm@gmail.com,http://www.cainjohnmesq.co.uk
+Corrinne,Jaret,Sound Vision Corp,2150 Morley St,Dee Ward,Dumfries and Galloway,DG8 7DE,01625-932209,01642-322954,corrinne_jaret@gmail.com,http://www.soundvisioncorp.co.uk
+Niesha,Bruch,Rowley/hansell Petetin,24 Bolton St,"Broxburn, Uphall and Winchburg",West Lothian,EH52 5TL,01874-856950,01342-793603,niesha.bruch@yahoo.com,http://www.rowleyhansellpetetin.co.uk
+Rueben,Gastellum,Industrial Engineering Assocs,4 Forrest St,Weston-Super-Mare,North Somerset,BS23 3HG,01976-755279,01956-535511,rueben_gastellum@gastellum.co.uk,http://www.industrialengineeringassocs.co.uk
+Michell,Throssell,Weiss Spirt & Guyer,89 Noon St,Carbrooke,Norfolk,IP25 6JQ,01967-580851,01672-496478,mthrossell@throssell.co.uk,http://www.weissspirtguyer.co.uk
+Edgar,Kanne,"Crowan, Kenneth W Esq",99 Guthrie St,New Milton,Hampshire,BH25 5DF,01326-532337,01666-638176,edgar.kanne@yahoo.com,http://www.crowankennethwesq.co.uk
+Dewitt,Julio,Rittenhouse Motor Co,7 Richmond St,Parkham,Devon,EX39 5DJ,01253-528327,01241-964675,dewitt.julio@hotmail.com,http://www.rittenhousemotorco.co.uk
+"""
+df = pd.read_csv(io.StringIO(csv))
+df.set_index("last_name", inplace=True)
+
+df.loc[df["first_name" == "Dewitt"], ["company_name", "email", "phone2"]]

--- a/pandas_tutor/tests/pg_wreck_it/parsing_warnings_01.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/parsing_warnings_01.py.golden
@@ -1,0 +1,20 @@
+{
+  "code": "# https://www.shanelynn.ie/pandas-iloc-loc-select-rows-and-columns-dataframe/\nimport pandas as pd\nimport io\ncsv = \"\"\"\nfirst_name,last_name,company_name,address,city,county,postal,phone1,phone2,email,web\nAleshia,Tomkiewicz,Alan D Rosenburg Cpa Pc,14 Taylor St,St. Stephens Ward,Kent,CT2 7PP,01835-703597,01944-369967,atomkiewicz@hotmail.com,http://www.alandrosenburgcpapc.co.uk\nEvan,Zigomalas,Cap Gemini America,5 Binney St,Abbey Ward,Buckinghamshire,HP11 2AX,01937-864715,01714-737668,evan.zigomalas@gmail.com,http://www.capgeminiamerica.co.uk\nFrance,Andrade,\"Elliott, John W Esq\",8 Moor Place,East Southbourne and Tuckton W,Bournemouth,BH6 3BE,01347-368222,01935-821636,france.andrade@hotmail.com,http://www.elliottjohnwesq.co.uk\nUlysses,Mcwalters,\"Mcmahan, Ben L\",505 Exeter Rd,Hawerby cum Beesby,Lincolnshire,DN36 5RP,01912-771311,01302-601380,ulysses@hotmail.com,http://www.mcmahanbenl.co.uk\nTyisha,Veness,Champagne Room,5396 Forth Street,Greets Green and Lyng Ward,West Midlands,B70 9DT,01547-429341,01290-367248,tyisha.veness@hotmail.com,http://www.champagneroom.co.uk\nEric,Rampy,\"Thompson, Michael C Esq\",9472 Lind St,Desborough,Northamptonshire,NN14 2GH,01969-886290,01545-817375,erampy@rampy.co.uk,http://www.thompsonmichaelcesq.co.uk\nMarg,Grasmick,Wrangle Hill Auto Auct & Slvg,7457 Cowl St #70,Bargate Ward,Southampton,SO14 3TY,01865-582516,01362-620532,marg@hotmail.com,http://www.wranglehillautoauctslvg.co.uk\nLaquita,Hisaw,In Communications Inc,20 Gloucester Pl #96,Chirton Ward,Tyne & Wear,NE29 7AD,01746-394243,01590-982428,laquita@yahoo.com,http://www.incommunicationsinc.co.uk\nLura,Manzella,Bizerba Usa Inc,929 Augustine St,Staple Hill Ward,South Gloucestershire,BS16 4LL,01907-538509,01340-713951,lura@hotmail.com,http://www.bizerbausainc.co.uk\nYuette,Klapec,Max Video,45 Bradfield St #166,Parwich,Derbyshire,DE6 1QN,01903-649460,01933-512513,yuette.klapec@klapec.co.uk,http://www.maxvideo.co.uk\nFernanda,Writer,K & R Associates Inc,620 Northampton St,Wilmington,Kent,DA2 7PP,01630-202053,01687-879391,fernanda@writer.co.uk,http://www.krassociatesinc.co.uk\nCharlesetta,Erm,\"Cain, John M Esq\",5 Hygeia St,Loundsley Green Ward,Derbyshire,S40 4LY,01276-816806,01517-624517,charlesetta_erm@gmail.com,http://www.cainjohnmesq.co.uk\nCorrinne,Jaret,Sound Vision Corp,2150 Morley St,Dee Ward,Dumfries and Galloway,DG8 7DE,01625-932209,01642-322954,corrinne_jaret@gmail.com,http://www.soundvisioncorp.co.uk\nNiesha,Bruch,Rowley/hansell Petetin,24 Bolton St,\"Broxburn, Uphall and Winchburg\",West Lothian,EH52 5TL,01874-856950,01342-793603,niesha.bruch@yahoo.com,http://www.rowleyhansellpetetin.co.uk\nRueben,Gastellum,Industrial Engineering Assocs,4 Forrest St,Weston-Super-Mare,North Somerset,BS23 3HG,01976-755279,01956-535511,rueben_gastellum@gastellum.co.uk,http://www.industrialengineeringassocs.co.uk\nMichell,Throssell,Weiss Spirt & Guyer,89 Noon St,Carbrooke,Norfolk,IP25 6JQ,01967-580851,01672-496478,mthrossell@throssell.co.uk,http://www.weissspirtguyer.co.uk\nEdgar,Kanne,\"Crowan, Kenneth W Esq\",99 Guthrie St,New Milton,Hampshire,BH25 5DF,01326-532337,01666-638176,edgar.kanne@yahoo.com,http://www.crowankennethwesq.co.uk\nDewitt,Julio,Rittenhouse Motor Co,7 Richmond St,Parkham,Devon,EX39 5DJ,01253-528327,01241-964675,dewitt.julio@hotmail.com,http://www.rittenhousemotorco.co.uk\n\"\"\"\ndf = pd.read_csv(io.StringIO(csv))\ndf.set_index(\"last_name\", inplace=True)\n\ndf.loc[df[\"first_name\" == \"Dewitt\"], [\"company_name\", \"email\", \"phone2\"]]\n",
+  "explanation": [
+    {
+      "type": "RuntimeErrorInChain",
+      "code_step": "df.loc[df[\"first_name\" == \"Dewitt\"], [\"company_name\", \"email\", \"phone2\"]]",
+      "message": "KeyError: False\n",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 73
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/pg_wreck_it/parsing_warnings_02.py
+++ b/pandas_tutor/tests/pg_wreck_it/parsing_warnings_02.py
@@ -1,0 +1,28 @@
+# https://www.shanelynn.ie/pandas-iloc-loc-select-rows-and-columns-dataframe/
+import pandas as pd
+import io
+csv = """
+first_name,last_name,company_name,address,city,county,postal,phone1,phone2,email,web
+Aleshia,Tomkiewicz,Alan D Rosenburg Cpa Pc,14 Taylor St,St. Stephens Ward,Kent,CT2 7PP,01835-703597,01944-369967,atomkiewicz@hotmail.com,http://www.alandrosenburgcpapc.co.uk
+Evan,Zigomalas,Cap Gemini America,5 Binney St,Abbey Ward,Buckinghamshire,HP11 2AX,01937-864715,01714-737668,evan.zigomalas@gmail.com,http://www.capgeminiamerica.co.uk
+France,Andrade,"Elliott, John W Esq",8 Moor Place,East Southbourne and Tuckton W,Bournemouth,BH6 3BE,01347-368222,01935-821636,france.andrade@hotmail.com,http://www.elliottjohnwesq.co.uk
+Ulysses,Mcwalters,"Mcmahan, Ben L",505 Exeter Rd,Hawerby cum Beesby,Lincolnshire,DN36 5RP,01912-771311,01302-601380,ulysses@hotmail.com,http://www.mcmahanbenl.co.uk
+Tyisha,Veness,Champagne Room,5396 Forth Street,Greets Green and Lyng Ward,West Midlands,B70 9DT,01547-429341,01290-367248,tyisha.veness@hotmail.com,http://www.champagneroom.co.uk
+Eric,Rampy,"Thompson, Michael C Esq",9472 Lind St,Desborough,Northamptonshire,NN14 2GH,01969-886290,01545-817375,erampy@rampy.co.uk,http://www.thompsonmichaelcesq.co.uk
+Marg,Grasmick,Wrangle Hill Auto Auct & Slvg,7457 Cowl St #70,Bargate Ward,Southampton,SO14 3TY,01865-582516,01362-620532,marg@hotmail.com,http://www.wranglehillautoauctslvg.co.uk
+Laquita,Hisaw,In Communications Inc,20 Gloucester Pl #96,Chirton Ward,Tyne & Wear,NE29 7AD,01746-394243,01590-982428,laquita@yahoo.com,http://www.incommunicationsinc.co.uk
+Lura,Manzella,Bizerba Usa Inc,929 Augustine St,Staple Hill Ward,South Gloucestershire,BS16 4LL,01907-538509,01340-713951,lura@hotmail.com,http://www.bizerbausainc.co.uk
+Yuette,Klapec,Max Video,45 Bradfield St #166,Parwich,Derbyshire,DE6 1QN,01903-649460,01933-512513,yuette.klapec@klapec.co.uk,http://www.maxvideo.co.uk
+Fernanda,Writer,K & R Associates Inc,620 Northampton St,Wilmington,Kent,DA2 7PP,01630-202053,01687-879391,fernanda@writer.co.uk,http://www.krassociatesinc.co.uk
+Charlesetta,Erm,"Cain, John M Esq",5 Hygeia St,Loundsley Green Ward,Derbyshire,S40 4LY,01276-816806,01517-624517,charlesetta_erm@gmail.com,http://www.cainjohnmesq.co.uk
+Corrinne,Jaret,Sound Vision Corp,2150 Morley St,Dee Ward,Dumfries and Galloway,DG8 7DE,01625-932209,01642-322954,corrinne_jaret@gmail.com,http://www.soundvisioncorp.co.uk
+Niesha,Bruch,Rowley/hansell Petetin,24 Bolton St,"Broxburn, Uphall and Winchburg",West Lothian,EH52 5TL,01874-856950,01342-793603,niesha.bruch@yahoo.com,http://www.rowleyhansellpetetin.co.uk
+Rueben,Gastellum,Industrial Engineering Assocs,4 Forrest St,Weston-Super-Mare,North Somerset,BS23 3HG,01976-755279,01956-535511,rueben_gastellum@gastellum.co.uk,http://www.industrialengineeringassocs.co.uk
+Michell,Throssell,Weiss Spirt & Guyer,89 Noon St,Carbrooke,Norfolk,IP25 6JQ,01967-580851,01672-496478,mthrossell@throssell.co.uk,http://www.weissspirtguyer.co.uk
+Edgar,Kanne,"Crowan, Kenneth W Esq",99 Guthrie St,New Milton,Hampshire,BH25 5DF,01326-532337,01666-638176,edgar.kanne@yahoo.com,http://www.crowankennethwesq.co.uk
+Dewitt,Julio,Rittenhouse Motor Co,7 Richmond St,Parkham,Devon,EX39 5DJ,01253-528327,01241-964675,dewitt.julio@hotmail.com,http://www.rittenhousemotorco.co.uk
+"""
+df = pd.read_csv(io.StringIO(csv))
+df.set_index("last_name", inplace=True)
+
+df[df["first_name" == "Dewitt"]]

--- a/pandas_tutor/tests/pg_wreck_it/parsing_warnings_02.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/parsing_warnings_02.py.golden
@@ -1,0 +1,20 @@
+{
+  "code": "# https://www.shanelynn.ie/pandas-iloc-loc-select-rows-and-columns-dataframe/\nimport pandas as pd\nimport io\ncsv = \"\"\"\nfirst_name,last_name,company_name,address,city,county,postal,phone1,phone2,email,web\nAleshia,Tomkiewicz,Alan D Rosenburg Cpa Pc,14 Taylor St,St. Stephens Ward,Kent,CT2 7PP,01835-703597,01944-369967,atomkiewicz@hotmail.com,http://www.alandrosenburgcpapc.co.uk\nEvan,Zigomalas,Cap Gemini America,5 Binney St,Abbey Ward,Buckinghamshire,HP11 2AX,01937-864715,01714-737668,evan.zigomalas@gmail.com,http://www.capgeminiamerica.co.uk\nFrance,Andrade,\"Elliott, John W Esq\",8 Moor Place,East Southbourne and Tuckton W,Bournemouth,BH6 3BE,01347-368222,01935-821636,france.andrade@hotmail.com,http://www.elliottjohnwesq.co.uk\nUlysses,Mcwalters,\"Mcmahan, Ben L\",505 Exeter Rd,Hawerby cum Beesby,Lincolnshire,DN36 5RP,01912-771311,01302-601380,ulysses@hotmail.com,http://www.mcmahanbenl.co.uk\nTyisha,Veness,Champagne Room,5396 Forth Street,Greets Green and Lyng Ward,West Midlands,B70 9DT,01547-429341,01290-367248,tyisha.veness@hotmail.com,http://www.champagneroom.co.uk\nEric,Rampy,\"Thompson, Michael C Esq\",9472 Lind St,Desborough,Northamptonshire,NN14 2GH,01969-886290,01545-817375,erampy@rampy.co.uk,http://www.thompsonmichaelcesq.co.uk\nMarg,Grasmick,Wrangle Hill Auto Auct & Slvg,7457 Cowl St #70,Bargate Ward,Southampton,SO14 3TY,01865-582516,01362-620532,marg@hotmail.com,http://www.wranglehillautoauctslvg.co.uk\nLaquita,Hisaw,In Communications Inc,20 Gloucester Pl #96,Chirton Ward,Tyne & Wear,NE29 7AD,01746-394243,01590-982428,laquita@yahoo.com,http://www.incommunicationsinc.co.uk\nLura,Manzella,Bizerba Usa Inc,929 Augustine St,Staple Hill Ward,South Gloucestershire,BS16 4LL,01907-538509,01340-713951,lura@hotmail.com,http://www.bizerbausainc.co.uk\nYuette,Klapec,Max Video,45 Bradfield St #166,Parwich,Derbyshire,DE6 1QN,01903-649460,01933-512513,yuette.klapec@klapec.co.uk,http://www.maxvideo.co.uk\nFernanda,Writer,K & R Associates Inc,620 Northampton St,Wilmington,Kent,DA2 7PP,01630-202053,01687-879391,fernanda@writer.co.uk,http://www.krassociatesinc.co.uk\nCharlesetta,Erm,\"Cain, John M Esq\",5 Hygeia St,Loundsley Green Ward,Derbyshire,S40 4LY,01276-816806,01517-624517,charlesetta_erm@gmail.com,http://www.cainjohnmesq.co.uk\nCorrinne,Jaret,Sound Vision Corp,2150 Morley St,Dee Ward,Dumfries and Galloway,DG8 7DE,01625-932209,01642-322954,corrinne_jaret@gmail.com,http://www.soundvisioncorp.co.uk\nNiesha,Bruch,Rowley/hansell Petetin,24 Bolton St,\"Broxburn, Uphall and Winchburg\",West Lothian,EH52 5TL,01874-856950,01342-793603,niesha.bruch@yahoo.com,http://www.rowleyhansellpetetin.co.uk\nRueben,Gastellum,Industrial Engineering Assocs,4 Forrest St,Weston-Super-Mare,North Somerset,BS23 3HG,01976-755279,01956-535511,rueben_gastellum@gastellum.co.uk,http://www.industrialengineeringassocs.co.uk\nMichell,Throssell,Weiss Spirt & Guyer,89 Noon St,Carbrooke,Norfolk,IP25 6JQ,01967-580851,01672-496478,mthrossell@throssell.co.uk,http://www.weissspirtguyer.co.uk\nEdgar,Kanne,\"Crowan, Kenneth W Esq\",99 Guthrie St,New Milton,Hampshire,BH25 5DF,01326-532337,01666-638176,edgar.kanne@yahoo.com,http://www.crowankennethwesq.co.uk\nDewitt,Julio,Rittenhouse Motor Co,7 Richmond St,Parkham,Devon,EX39 5DJ,01253-528327,01241-964675,dewitt.julio@hotmail.com,http://www.rittenhousemotorco.co.uk\n\"\"\"\ndf = pd.read_csv(io.StringIO(csv))\ndf.set_index(\"last_name\", inplace=True)\n\ndf[df[\"first_name\" == \"Dewitt\"]]\n",
+  "explanation": [
+    {
+      "type": "RuntimeErrorInChain",
+      "code_step": "df[df[\"first_name\" == \"Dewitt\"]]",
+      "message": "KeyError: False\n",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 32
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/test_pg_wreck_it.py
+++ b/pandas_tutor/tests/test_pg_wreck_it.py
@@ -1,6 +1,9 @@
+import contextlib
+import io
 import os
-from pathlib import Path
+import sys
 import unittest
+from pathlib import Path
 
 from ..main import make_tutor_spec
 
@@ -8,7 +11,24 @@ test_cases = Path(__file__).parent / 'pg_wreck_it'
 
 
 class TestEndToEnd(unittest.TestCase):
-    pass
+    @classmethod
+    def setUpClass(cls):
+        # capture stdout and stderr to avoid cluttering test output.
+        cls._stdout = io.StringIO()
+        cls._context_stdout = contextlib.redirect_stdout(cls._stdout)
+
+        cls._stderr = io.StringIO()
+        cls._context_stderr = contextlib.redirect_stderr(cls._stderr)
+
+        cls._context_stdout.__enter__()
+        cls._context_stderr.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._context_stdout.__exit__(None, None, None)
+        cls._context_stderr.__exit__(None, None, None)
+
+        # we can print captured stdout and stderr if needed, in the future
 
 
 def make_test_case(test_name):

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -7,7 +7,6 @@ import base64
 import dataclasses
 import gzip
 import io
-import sys
 import typing as t
 import warnings
 
@@ -23,11 +22,6 @@ Labels = t.Union[t.List[int], t.List[str]]
 HasIndex = t.Union[pd.DataFrame, pd.Series]
 
 Groups = t.Dict[t.Union[str, tuple], pd.Index]
-
-
-# hacky way of checking whether we're in the testing env
-def in_testing_env() -> bool:
-    return 'unittest' in sys.modules
 
 
 def mapt(fn, *args):


### PR DESCRIPTION
fixes #54 

for whatever reason, `pandas.core.indexing.IndexingError` inherits
directly from `Exception` so we weren't catching it.

now, we'll just catch the `Exception` class. this doesn't include
`SystemExit` and `KeyboardInterrupt`, so hopefully it doesn't make the
backend behave badly.