### PR TITLE
fix bug in serializing groupby

### DIFF
--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -107,7 +107,7 @@ def serialize_groupby(val: util.DataFrameGroupBy) -> GroupBySpec:
 
     df_groups = t.cast(util.Groups, val.groups)
     groups = [
-        Group(name=[name] if isinstance(name, str) else list(name),
+        Group(name=list(name) if util.is_list_like(name) else [name],
               labels=labels.tolist()) for name, labels in df_groups.items()
     ]
 
@@ -126,7 +126,7 @@ def serialize_seriesgroupby(val: util.SeriesGroupBy) -> SeriesGroupBySpec:
 
     df_groups = t.cast(util.Groups, val.groups)
     groups = [
-        Group(name=[name] if isinstance(name, str) else list(name),
+        Group(name=list(name) if util.is_list_like(name) else [name],
               labels=labels.tolist()) for name, labels in df_groups.items()
     ]
 

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py
@@ -1,0 +1,7 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html
+import pandas as pd
+import numpy as np
+
+lst = [1, 2, 3, 4, 5, 6] # <-- this was initially [1, 2, 3, 1, 2, 3] so i thought it was a duplicate index issue, but even with no duplicates it still crashes
+s = pd.Series([1, 2, 3, 10, 20, 30], lst)
+s.groupby(level=0)

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py.golden
@@ -1,0 +1,115 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html\nimport pandas as pd\nimport numpy as np\n\nlst = [1, 2, 3, 4, 5, 6] # <-- this was initially [1, 2, 3, 1, 2, 3] so i thought it was a duplicate index issue, but even with no duplicates it still crashes\ns = pd.Series([1, 2, 3, 10, 20, 30], lst)\ns.groupby(level=0)\n",
+  "explanation": [
+    {
+      "type": "GroupByCall",
+      "code_step": "s.groupby(level=0)",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 1
+        },
+        "end": {
+          "line": 0,
+          "ch": 18
+        }
+      },
+      "mapping": [],
+      "data_frame": {
+        "lhs": {
+          "type": "Series",
+          "row_labels": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            1,
+            2,
+            3,
+            10,
+            20,
+            30
+          ]
+        },
+        "rhs": {
+          "type": "SeriesGroupBy",
+          "row_labels": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            1,
+            2,
+            3,
+            10,
+            20,
+            30
+          ],
+          "group_data": {
+            "col_names": [
+              null
+            ],
+            "groups": [
+              {
+                "name": [
+                  1
+                ],
+                "labels": [
+                  1
+                ]
+              },
+              {
+                "name": [
+                  2
+                ],
+                "labels": [
+                  2
+                ]
+              },
+              {
+                "name": [
+                  3
+                ],
+                "labels": [
+                  3
+                ]
+              },
+              {
+                "name": [
+                  4
+                ],
+                "labels": [
+                  4
+                ]
+              },
+              {
+                "name": [
+                  5
+                ],
+                "labels": [
+                  5
+                ]
+              },
+              {
+                "name": [
+                  6
+                ],
+                "labels": [
+                  6
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py
@@ -1,0 +1,5 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html
+import pandas as pd
+df_list = [[1, 2, 3], [1, None, 4], [2, 1, 3], [1, 2, 2]]
+df_dropna = pd.DataFrame(df_list, columns=["a", "b", "c"])
+df_dropna.groupby(by=["b"])

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
@@ -1,0 +1,125 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html\nimport pandas as pd\ndf_list = [[1, 2, 3], [1, None, 4], [2, 1, 3], [1, 2, 2]]\ndf_dropna = pd.DataFrame(df_list, columns=[\"a\", \"b\", \"c\"])\ndf_dropna.groupby(by=[\"b\"])\n",
+  "explanation": [
+    {
+      "type": "GroupByCall",
+      "code_step": "df_dropna.groupby(by=[\"b\"])",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 9
+        },
+        "end": {
+          "line": 0,
+          "ch": 27
+        }
+      },
+      "mapping": [
+        {
+          "select": "column",
+          "anchor": "lhs",
+          "label": "b",
+          "illustrate": "highlight"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "a",
+            "b",
+            "c"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "data": [
+            [
+              1.0,
+              2.0,
+              3.0
+            ],
+            [
+              1.0,
+              null,
+              4.0
+            ],
+            [
+              2.0,
+              1.0,
+              3.0
+            ],
+            [
+              1.0,
+              2.0,
+              2.0
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrameGroupBy",
+          "col_names": [
+            "a",
+            "b",
+            "c"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "data": [
+            [
+              1.0,
+              2.0,
+              3.0
+            ],
+            [
+              1.0,
+              null,
+              4.0
+            ],
+            [
+              2.0,
+              1.0,
+              3.0
+            ],
+            [
+              1.0,
+              2.0,
+              2.0
+            ]
+          ],
+          "group_data": {
+            "col_names": [
+              "b"
+            ],
+            "groups": [
+              {
+                "name": [
+                  1.0
+                ],
+                "labels": [
+                  2
+                ]
+              },
+              {
+                "name": [
+                  2.0
+                ],
+                "labels": [
+                  0,
+                  3
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -9,6 +9,7 @@ import gzip
 import io
 import typing as t
 import warnings
+import collections.abc
 
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy, SeriesGroupBy
@@ -27,6 +28,16 @@ Groups = t.Dict[t.Union[str, tuple], pd.Index]
 def mapt(fn, *args):
     "map(fn, *args) and return the result as a tuple."
     return tuple(map(fn, *args))
+
+
+def is_list_like(obj: t.Any) -> bool:
+    '''
+    checks whether obj is a list-like. we need this because we don't usually
+    want to do list(string), but we want to convert other types of list-like
+    things to lists
+    '''
+    return (not isinstance(obj, str)
+            and isinstance(obj, collections.abc.Iterable))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
fixes #64 
fixes #65 

we were assuming group keys were either strings or list-likes. instead, we should differentiate group keys by whether they are scalars or iterables.