### PR TITLE
draw arrows when filtering into a column series

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -246,6 +246,8 @@ def mark_for_subscript_into_series(
     after: t.Union[SeriesResult, SeriesGroupbyResult],
 ) -> t.List[Mark]:
     args = after.args
+    before_df = util.ungroup(before.val)
+    after_df = util.ungroup(after.val)
 
     # df['kids']
     if step.slicer is None:
@@ -275,7 +277,7 @@ def mark_for_subscript_into_series(
     if isinstance(maybe_row, (str, int)):
         row = util.positions_to_labels(
             maybe_row,
-            df=util.ungroup(before.val),
+            df=before_df,
             slicer=step.slicer,
             axis='index',
         )
@@ -283,6 +285,9 @@ def mark_for_subscript_into_series(
         return [
             *rows_used_for_filter,
             Outline(select='row', from_=lhs(row), to=rhs_series()),
+            # when slicing a row out of dataframe, the resulting series has
+            # the df's column labels as the index. this means that the labels
+            # are "transposed" so we don't draw arrows for this case.
         ]
 
     # df.iloc[:, 0]
@@ -290,13 +295,16 @@ def mark_for_subscript_into_series(
     if isinstance(maybe_col, (str, int)):
         col = util.positions_to_labels(
             maybe_col,
-            df=util.ungroup(before.val),
+            df=before_df,
             slicer=step.slicer,
             axis='columns',
         )
         return [
             *cols_used_for_filter,
             Outline(select='column', from_=lhs(col), to=rhs_series()),
+            *diff_rows(before_df,
+                       after_df,
+                       only_if_diff=(len(cols_used_for_filter) == 0)),
         ]
 
     return []

--- a/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
@@ -32,6 +32,42 @@
             "label": "pandas.Series"
           },
           "illustrate": "outline"
+        },
+        {
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 3
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": 3
+          },
+          "illustrate": "outline"
+        },
+        {
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 4
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": 4
+          },
+          "illustrate": "outline"
+        },
+        {
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 9
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": 9
+          },
+          "illustrate": "outline"
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/filter_into_series_row.py
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series_row.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+mydict = [{'a': 1, 'b': 2, 'c': 3, 'd': 4},
+          {'a': 100, 'b': 200, 'c': 300, 'd': 400},
+          {'a': 1000, 'b': 2000, 'c': 3000, 'd': 4000 }]
+
+df = pd.DataFrame(mydict, index=['one', 'two', 'three'])
+
+df.loc['one', df.loc['two'] > 200]

--- a/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
@@ -1,0 +1,86 @@
+{
+  "code": "import pandas as pd\n\nmydict = [{'a': 1, 'b': 2, 'c': 3, 'd': 4},\n          {'a': 100, 'b': 200, 'c': 300, 'd': 400},\n          {'a': 1000, 'b': 2000, 'c': 3000, 'd': 4000 }]\n\ndf = pd.DataFrame(mydict, index=['one', 'two', 'three'])\n\ndf.loc['one', df.loc['two'] > 200]",
+  "explanation": [
+    {
+      "type": "Subscript",
+      "code_step": "df.loc['one', df.loc['two'] > 200]",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 34
+        }
+      },
+      "mapping": [
+        {
+          "select": "row",
+          "anchor": "lhs",
+          "label": "two",
+          "illustrate": "highlight"
+        },
+        {
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": "one"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "pandas.Series"
+          },
+          "illustrate": "outline"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "a",
+            "b",
+            "c",
+            "d"
+          ],
+          "row_labels": [
+            "one",
+            "two",
+            "three"
+          ],
+          "data": [
+            [
+              1,
+              2,
+              3,
+              4
+            ],
+            [
+              100,
+              200,
+              300,
+              400
+            ],
+            [
+              1000,
+              2000,
+              3000,
+              4000
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [
+            "c",
+            "d"
+          ],
+          "data": [
+            3,
+            4
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
fixes #75 

now, when we filter using a column and the result is a series, we draw arrows between rows, as in:

https://github.com/SamLau95/pandas_tutor/blob/7dba96a1d5c9cf4799fde0f16cc45f0eeae5bd39/pandas_tutor/tests/e2e_golden/filter_into_series.py#L28

but, when we filter using a row, we don't draw arrows:

https://github.com/SamLau95/pandas_tutor/blob/7dba96a1d5c9cf4799fde0f16cc45f0eeae5bd39/pandas_tutor/tests/e2e_golden/filter_into_series_row.py#L9

when we slice a row of a dataframe and the result is a series, the column labels of the existing dataframe become the row labels of the series. i'm not sure whether we want to draw arrows for the "transpose" case yet.

<img width="641" alt="Screen Shot 2021-11-30 at 6 31 08 PM" src="https://user-images.githubusercontent.com/2468904/144161223-3262ddab-ce80-483b-919c-3dc0a9cd860a.png">


