### PR TITLE
implement DataFrame.drop() and Series.drop()

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -6,11 +6,11 @@ import typing as t
 import pandas as pd
 
 from . import util
-from .diagram import Highlight, Mark, Outline, Selection, TablePos
+from .diagram import CrossOut, Highlight, Mark, Outline, Selection, TablePos
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStep,
-                          EvalError, GroupByCall, HeadCall, PassThroughCall,
-                          RenameCall, SortValuesCall, SubsComparison,
-                          Subscript, SubscriptEl, TailCall)
+                          DropCall, EvalError, GroupByCall, HeadCall,
+                          PassThroughCall, RenameCall, SortValuesCall,
+                          SubsComparison, Subscript, SubscriptEl, TailCall)
 from .run import (Arg, DFResult, EvalResult, GroupbyResult,
                   SeriesGroupbyResult, SeriesResult)
 
@@ -25,6 +25,8 @@ def make_marks(step: ChainStep, before: EvalResult,
         return no_marks()
     elif isinstance(step, SortValuesCall):
         return mark_for_sort_values(step, before, after)
+    elif isinstance(step, DropCall):
+        return mark_for_drop(step, before, after)
     elif isinstance(step, RenameCall):
         return mark_for_rename(step, before, after)
     elif isinstance(step, HeadCall) or isinstance(step, TailCall):
@@ -64,6 +66,22 @@ def mark_for_sort_values(step: SortValuesCall, before: EvalResult,
                                  anchor='rhs')
     outlines = make_outlines(sorted_labels, selection(step.axis))
     return [*highlights, *outlines]
+
+
+# dogs.drop(columns=['type', 'price'])
+def mark_for_drop(step: DropCall, before: EvalResult,
+                  after: EvalResult) -> t.List[Mark]:
+    if not (isinstance(before, (DFResult, SeriesResult))
+            and isinstance(after, (DFResult, SeriesResult))):
+        return []
+    args = after.args
+
+    labels = args.get('labels', [])
+    if isinstance(labels, str):
+        labels = [labels]
+
+    # cross out dropped rows or columns
+    return make_crossouts(labels, selection(step.axis))
 
 
 # df.rename(index={'sam': 'smae'})
@@ -364,12 +382,26 @@ def make_highlights(labels: t.Iterable,
 
 def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     '''
-    used as a shorthand when index values don't change, which is most of the
-    time
+    shorthand when index values don't change, which is most of the time
     '''
     return [
         Outline(select=select, from_=lhs(label), to=rhs(label))
         for label in labels
+    ]
+
+
+def make_crossouts(labels: t.Iterable, select: Selection) -> t.List[Mark]:
+    '''
+    shorthand for crossouts
+    '''
+    # we haven't implemented arg anchors yet, so use a dummy value for now
+    dummy_arg_anchor = {'anchor': 'arg', 'index': 0}
+    return [
+        CrossOut(
+            select=select,
+            from_=dummy_arg_anchor,  # type: ignore
+            to=lhs(label),
+        ) for label in labels
     ]
 
 

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -24,11 +24,11 @@ import libcst.matchers as m
 import libcst.metadata as cstm
 
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStatement,
-                          ChainStep, GroupByCall, HeadCall, ParseResult,
-                          ParsedModule, ParseSyntaxError, PassThroughCall,
-                          RawCode, RenameCall, SortValuesCall, StartOfChain,
-                          SubsComparison, Subscript, SubscriptEl, SubsEval,
-                          SubsSlice, TailCall, VerbatimStatement)
+                          ChainStep, DropCall, GroupByCall, HeadCall,
+                          ParseResult, ParsedModule, ParseSyntaxError,
+                          PassThroughCall, RawCode, RenameCall, SortValuesCall,
+                          StartOfChain, SubsComparison, Subscript, SubscriptEl,
+                          SubsEval, SubsSlice, TailCall, VerbatimStatement)
 from .util import CodePosition, CodeRange
 from . import util
 
@@ -83,6 +83,7 @@ def fn_name(call: cst.Call):
 
 
 is_sort_values = fn_matcher('sort_values')
+is_drop = fn_matcher('drop')
 is_rename = fn_matcher('rename')
 is_head_or_tail = fn_matcher('head') | fn_matcher('tail')
 is_groupby = fn_matcher('groupby')
@@ -90,8 +91,8 @@ is_apply = fn_matcher('apply')
 is_assign = fn_matcher('assign')
 
 # make sure to update this whenever we add a new call to the section above
-is_parsed_call = (is_sort_values | is_rename | is_head_or_tail | is_groupby
-                  | is_apply | is_assign)
+is_parsed_call = (is_sort_values | is_drop | is_rename | is_head_or_tail
+                  | is_groupby | is_apply | is_assign)
 
 is_loc_iloc = m.Subscript(value=m.Attribute(attr=m.Name('loc')
                                             | m.Name('iloc')))
@@ -306,6 +307,31 @@ class ChainParser(ParserBase):
                 if axis_arg is not None else 'index')
 
         node = self.make_call_node(SortValuesCall,
+                                   cst_node,
+                                   label_expr=label_expr,
+                                   axis=axis)
+        self._append(node)
+
+    @m.leave(is_drop)
+    def make_drop_call(self, cst_node):
+        labels = get_arg_by_position_or_keyword(cst_node.args, 0, 'labels')
+        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, 'axis')
+        index = get_arg_by_position_or_keyword(cst_node.args, 2, 'index')
+        columns = get_arg_by_position_or_keyword(cst_node.args, 3, 'columns')
+        axis = 'index'  # default
+
+        if index is not None:
+            labels = index
+            axis = 'index'
+        elif columns is not None:
+            labels = columns
+            axis = 'columns'
+        elif axis_arg is not None:
+            axis = make_axis(self.code_for(axis_arg.value))
+
+        label_expr = self.code_for(labels.value) if labels is not None else ''
+
+        node = self.make_call_node(DropCall,
                                    cst_node,
                                    label_expr=label_expr,
                                    axis=axis)

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -218,6 +218,20 @@ class AssignCall(Call):
     new_col_labels: t.List[str]
 
 
+@dataclasses.dataclass
+class DropCall(Call):
+    '''
+    dogs.drop(columns=['type', 'price'])
+    dogs.drop(['Labrador Retriever', 'Beagle'])
+    '''
+    fn_name = 'drop'
+
+    # Expression that evaluates to labels
+    label_expr: RawCode = evals_into('labels')
+
+    axis: Axis = 'index'
+
+
 ##############################################################################
 # Subscripts
 ##############################################################################

--- a/pandas_tutor/tests/e2e_golden/drop_columns.py
+++ b/pandas_tutor/tests/e2e_golden/drop_columns.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,type,price,longevity,size
+Labrador Retriever,sporting,810.0,12.04,medium
+German Shepherd,herding,820.0,9.73,large
+Beagle,hound,288.0,12.3,small
+'''
+
+dogs = pd.read_csv(io.StringIO(csv)).set_index('breed')
+
+(dogs
+ .drop(columns=['type', 'price'])
+)

--- a/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
@@ -1,0 +1,107 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,type,price,longevity,size\nLabrador Retriever,sporting,810.0,12.04,medium\nGerman Shepherd,herding,820.0,9.73,large\nBeagle,hound,288.0,12.3,small\n'''\n\ndogs = pd.read_csv(io.StringIO(csv)).set_index('breed')\n\n(dogs\n .drop(columns=['type', 'price'])\n)\n",
+  "explanation": [
+    {
+      "type": "DropCall",
+      "code_step": "(dogs\n .drop(columns=['type', 'price'])\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 33
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "crossout",
+          "select": "column",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "type"
+          }
+        },
+        {
+          "illustrate": "crossout",
+          "select": "column",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "price"
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "type",
+            "price",
+            "longevity",
+            "size"
+          ],
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle"
+          ],
+          "data": [
+            [
+              "sporting",
+              810.0,
+              12.04,
+              "medium"
+            ],
+            [
+              "herding",
+              820.0,
+              9.73,
+              "large"
+            ],
+            [
+              "hound",
+              288.0,
+              12.3,
+              "small"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "longevity",
+            "size"
+          ],
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle"
+          ],
+          "data": [
+            [
+              12.04,
+              "medium"
+            ],
+            [
+              9.73,
+              "large"
+            ],
+            [
+              12.3,
+              "small"
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/drop_rows.py
+++ b/pandas_tutor/tests/e2e_golden/drop_rows.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,type,price,longevity,size
+Labrador Retriever,sporting,810.0,12.04,medium
+German Shepherd,herding,820.0,9.73,large
+Beagle,hound,288.0,12.3,small
+'''
+
+dogs = pd.read_csv(io.StringIO(csv)).set_index('breed')
+
+(dogs
+ .drop(['Labrador Retriever', 'Beagle'])
+)

--- a/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
@@ -1,0 +1,101 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,type,price,longevity,size\nLabrador Retriever,sporting,810.0,12.04,medium\nGerman Shepherd,herding,820.0,9.73,large\nBeagle,hound,288.0,12.3,small\n'''\n\ndogs = pd.read_csv(io.StringIO(csv)).set_index('breed')\n\n(dogs\n .drop(['Labrador Retriever', 'Beagle'])\n)\n",
+  "explanation": [
+    {
+      "type": "DropCall",
+      "code_step": "(dogs\n .drop(['Labrador Retriever', 'Beagle'])\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 40
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "Labrador Retriever"
+          }
+        },
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "Beagle"
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "type",
+            "price",
+            "longevity",
+            "size"
+          ],
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle"
+          ],
+          "data": [
+            [
+              "sporting",
+              810.0,
+              12.04,
+              "medium"
+            ],
+            [
+              "herding",
+              820.0,
+              9.73,
+              "large"
+            ],
+            [
+              "hound",
+              288.0,
+              12.3,
+              "small"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "type",
+            "price",
+            "longevity",
+            "size"
+          ],
+          "row_labels": [
+            "German Shepherd"
+          ],
+          "data": [
+            [
+              "herding",
+              820.0,
+              9.73,
+              "large"
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/drop_series.py
+++ b/pandas_tutor/tests/e2e_golden/drop_series.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,type,price,longevity,size
+Labrador Retriever,sporting,810.0,12.04,medium
+German Shepherd,herding,820.0,9.73,large
+Beagle,hound,288.0,12.3,small
+'''
+
+dogs = pd.read_csv(io.StringIO(csv)).set_index('breed')
+
+prices = dogs['price']
+
+(prices
+ .drop(['Labrador Retriever', 'Beagle'])
+)

--- a/pandas_tutor/tests/e2e_golden/drop_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_series.py.golden
@@ -1,0 +1,69 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,type,price,longevity,size\nLabrador Retriever,sporting,810.0,12.04,medium\nGerman Shepherd,herding,820.0,9.73,large\nBeagle,hound,288.0,12.3,small\n'''\n\ndogs = pd.read_csv(io.StringIO(csv)).set_index('breed')\n\nprices = dogs['price']\n\n(prices\n .drop(['Labrador Retriever', 'Beagle'])\n)\n",
+  "explanation": [
+    {
+      "type": "DropCall",
+      "code_step": "(prices\n .drop(['Labrador Retriever', 'Beagle'])\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 40
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "Labrador Retriever"
+          }
+        },
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "Beagle"
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "Series",
+          "row_labels": [
+            "Labrador Retriever",
+            "German Shepherd",
+            "Beagle"
+          ],
+          "data": [
+            810.0,
+            820.0,
+            288.0
+          ]
+        },
+        "rhs": {
+          "type": "Series",
+          "row_labels": [
+            "German Shepherd"
+          ],
+          "data": [
+            820.0
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
now we support drop() calls like:

https://github.com/SamLau95/pandas_tutor/blob/a690bea00b93849336e0a296e81230325963bacb/pandas_tutor/tests/e2e_golden/drop_columns.py#L13-L15

we use the crossout mark for these:

https://github.com/SamLau95/pandas_tutor/blob/a690bea00b93849336e0a296e81230325963bacb/pandas_tutor/tests/e2e_golden/drop_columns.py.golden#L18-L29

notice that `"anchor": "arg"` is supposed to reference the code itself, but we aren't doing that right now in the parser so we're just hard-coding the arg as 0.