### PR TITLE
fix buggy drop() calls

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -77,7 +77,7 @@ def mark_for_drop(step: DropCall, before: EvalResult,
     args = after.args
 
     labels = args.get('labels', [])
-    if isinstance(labels, str):
+    if isinstance(labels, (str, int)):
         labels = [labels]
 
     # cross out dropped rows or columns

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -76,12 +76,19 @@ def mark_for_drop(step: DropCall, before: EvalResult,
         return []
     args = after.args
 
-    labels = args.get('labels', [])
-    if isinstance(labels, (str, int)):
-        labels = [labels]
+    col_labels = args.get('col_labels', [])
+    if not util.is_list_like(col_labels):
+        col_labels = [col_labels]
+
+    row_labels = args.get('row_labels', [])
+    if not util.is_list_like(row_labels):
+        row_labels = [row_labels]
 
     # cross out dropped rows or columns
-    return make_crossouts(labels, selection(step.axis))
+    return [
+        *make_crossouts(col_labels, 'column'),
+        *make_crossouts(row_labels, 'row')
+    ]
 
 
 # df.rename(index={'sam': 'smae'})

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -120,7 +120,9 @@ def get_arg_by_position_or_keyword(
                 return arg
     if position >= len(args):
         return None
-    return args[position]
+
+    arg = args[position]
+    return arg if arg.keyword is None else None
 
 
 def make_axis(value: str) -> Axis:
@@ -316,25 +318,32 @@ class ChainParser(ParserBase):
     def make_drop_call(self, cst_node):
         labels = get_arg_by_position_or_keyword(cst_node.args, 0, 'labels')
         axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, 'axis')
-        index = get_arg_by_position_or_keyword(cst_node.args, 2, 'index')
-        columns = get_arg_by_position_or_keyword(cst_node.args, 3, 'columns')
+        row_expr = get_arg_by_position_or_keyword(cst_node.args, 2, 'index')
+        col_expr = get_arg_by_position_or_keyword(cst_node.args, 3, 'columns')
         axis = 'index'  # default
 
-        if index is not None:
-            labels = index
-            axis = 'index'
-        elif columns is not None:
-            labels = columns
-            axis = 'columns'
-        elif axis_arg is not None:
+        if row_expr is not None:
+            row_expr = (self.code_for(row_expr.value)
+                        if row_expr is not None else '')
+        if col_expr is not None:
+            col_expr = (self.code_for(col_expr.value)
+                        if col_expr is not None else '')
+
+        if axis_arg is not None:
             axis = make_axis(self.code_for(axis_arg.value))
 
-        label_expr = self.code_for(labels.value) if labels is not None else ''
+        if labels is not None:
+            if axis == 'columns':
+                col_expr = (self.code_for(labels.value)
+                            if labels is not None else '')
+            else:
+                row_expr = (self.code_for(labels.value)
+                            if labels is not None else '')
 
         node = self.make_call_node(DropCall,
                                    cst_node,
-                                   label_expr=label_expr,
-                                   axis=axis)
+                                   col_expr=col_expr,
+                                   row_expr=row_expr)
         self._append(node)
 
     @m.leave(is_rename)

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -399,12 +399,7 @@ class ChainParser(ParserBase):
 
     @m.leave(is_groupby)
     def make_groupby(self, cst_node):
-        by = get_arg_by_position_or_keyword(cst_node.args, 0, 'by')
         axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, 'axis')
-
-        if by is None:
-            self.fallback_call(cst_node)
-            return
 
         # default groupby uses rows
         axis = (make_axis(self.code_for(axis_arg.value))

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -226,10 +226,8 @@ class DropCall(Call):
     '''
     fn_name = 'drop'
 
-    # Expression that evaluates to labels
-    label_expr: RawCode = evals_into('labels')
-
-    axis: Axis = 'index'
+    col_expr: t.Optional[RawCode] = evals_into('col_labels')
+    row_expr: t.Optional[RawCode] = evals_into('row_labels')
 
 
 ##############################################################################

--- a/pandas_tutor/run.py
+++ b/pandas_tutor/run.py
@@ -224,8 +224,11 @@ def eval_dataclass(obj: t.Any, user_globals: dict, attr='') -> Args:
 
     for field in fields:
         evals_into = field.metadata['evals_into'].format(attr=attr)
-        to_eval: t.Union[RawCode, t.List[RawCode]] = getattr(obj, field.name)
-        if isinstance(to_eval, list):
+        to_eval: t.Union[None, RawCode,
+                         t.List[RawCode]] = getattr(obj, field.name)
+        if to_eval is None:
+            continue
+        elif isinstance(to_eval, list):
             result = [eval(f"({code})", user_globals) for code in to_eval]
         else:
             result = eval(f"({to_eval})", user_globals)

--- a/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,type,longevity,size
+Labrador Retriever,sporting,12.04,medium
+German Shepherd,herding,9.73,large
+Beagle,hound,12.3,small
+Golden,sporting,12.04,medium
+Yorkshire,toy,12.6,small
+Bulldog,non-sporting,6.29,medium
+'''
+
+dogs = (pd.read_csv(io.StringIO(csv))
+  [['breed', 'type', 'longevity']]
+)
+
+(dogs
+ .drop(columns=['type'], index=1)
+)

--- a/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
@@ -1,0 +1,131 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,type,longevity,size\nLabrador Retriever,sporting,12.04,medium\nGerman Shepherd,herding,9.73,large\nBeagle,hound,12.3,small\nGolden,sporting,12.04,medium\nYorkshire,toy,12.6,small\nBulldog,non-sporting,6.29,medium\n'''\n\ndogs = (pd.read_csv(io.StringIO(csv))\n  [['breed', 'type', 'longevity']]\n)\n\n(dogs\n .drop(columns=['type'], index=1)\n)",
+  "explanation": [
+    {
+      "type": "DropCall",
+      "code_step": "(dogs\n .drop(columns=['type'], index=1)\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 33
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "crossout",
+          "select": "column",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": "type"
+          }
+        },
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": 1
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "type",
+            "longevity"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "sporting",
+              12.04
+            ],
+            [
+              "German Shepherd",
+              "herding",
+              9.73
+            ],
+            [
+              "Beagle",
+              "hound",
+              12.3
+            ],
+            [
+              "Golden",
+              "sporting",
+              12.04
+            ],
+            [
+              "Yorkshire",
+              "toy",
+              12.6
+            ],
+            [
+              "Bulldog",
+              "non-sporting",
+              6.29
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "longevity"
+          ],
+          "row_labels": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              12.04
+            ],
+            [
+              "Beagle",
+              12.3
+            ],
+            [
+              "Golden",
+              12.04
+            ],
+            [
+              "Yorkshire",
+              12.6
+            ],
+            [
+              "Bulldog",
+              6.29
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/drop_rows_index.py
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_index.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,type,longevity,size
+Labrador Retriever,sporting,12.04,medium
+German Shepherd,herding,9.73,large
+Beagle,hound,12.3,small
+Golden,sporting,12.04,medium
+Yorkshire,toy,12.6,small
+Bulldog,non-sporting,6.29,medium
+'''
+
+dogs = (pd.read_csv(io.StringIO(csv))
+  [['breed', 'type', 'longevity']]
+)
+
+dogs.drop(index=1, axis=1)

--- a/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
@@ -1,0 +1,125 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,type,longevity,size\nLabrador Retriever,sporting,12.04,medium\nGerman Shepherd,herding,9.73,large\nBeagle,hound,12.3,small\nGolden,sporting,12.04,medium\nYorkshire,toy,12.6,small\nBulldog,non-sporting,6.29,medium\n'''\n\ndogs = (pd.read_csv(io.StringIO(csv))\n  [['breed', 'type', 'longevity']]\n)\n\ndogs.drop(index=1, axis=1)",
+  "explanation": [
+    {
+      "type": "DropCall",
+      "code_step": "dogs.drop(index=1, axis=1)",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 4
+        },
+        "end": {
+          "line": 0,
+          "ch": 26
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "crossout",
+          "select": "row",
+          "from": {
+            "anchor": "arg",
+            "index": 0
+          },
+          "to": {
+            "anchor": "lhs",
+            "label": 1
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "type",
+            "longevity"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "sporting",
+              12.04
+            ],
+            [
+              "German Shepherd",
+              "herding",
+              9.73
+            ],
+            [
+              "Beagle",
+              "hound",
+              12.3
+            ],
+            [
+              "Golden",
+              "sporting",
+              12.04
+            ],
+            [
+              "Yorkshire",
+              "toy",
+              12.6
+            ],
+            [
+              "Bulldog",
+              "non-sporting",
+              6.29
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "type",
+            "longevity"
+          ],
+          "row_labels": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "sporting",
+              12.04
+            ],
+            [
+              "Beagle",
+              "hound",
+              12.3
+            ],
+            [
+              "Golden",
+              "sporting",
+              12.04
+            ],
+            [
+              "Yorkshire",
+              "toy",
+              12.6
+            ],
+            [
+              "Bulldog",
+              "non-sporting",
+              6.29
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
closes #94 

drop() calls can drop BOTH rows and columns in one go! we weren't supporting that before but now we are.

https://github.com/SamLau95/pandas_tutor/blob/3f05d7ba5495921c33660547208d2bb68b6bc4eb/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py#L18-L20

produces 2 crossout marks, one for column and one for row.