### PR TITLE
implement groupby with multiple group keys

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -3,15 +3,12 @@ has dataclass definitions for final JSON output.
 '''
 
 from __future__ import annotations
-from abc import ABC, abstractmethod
 
 import dataclasses
 from traceback import TracebackException
 import typing as t
 from dataclasses import field
 
-import numpy as np
-import pandas as pd
 import simplejson as json
 
 from .parse_nodes import ParseSyntaxError
@@ -46,6 +43,7 @@ def encode_dataclasses(obj: t.Any):
     if dataclasses.is_dataclass(obj):
         return dataclasses.asdict(obj, dict_factory=_diagram_as_dict)
     return obj
+
 
 ##############################################################################
 # Explanation

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -6,7 +6,8 @@ import typing as t
 import pandas as pd
 
 from . import util
-from .diagram import CrossOut, Highlight, Mark, Outline, Selection, TablePos
+from .diagram import (Anchor, CrossOut, Highlight, Mark, Outline, Selection,
+                      TablePos)
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStep,
                           DropCall, EvalError, GroupByCall, HeadCall,
                           PassThroughCall, RenameCall, SortValuesCall,
@@ -173,11 +174,6 @@ def mark_for_agg(step: AggCall, before: EvalResult,
 
     row_outlines: t.List[Mark] = []
     for group_key, lhs_labels in groups.items():
-        # don't draw anything if we have a multi-column group
-        # TODO: support multi-column grouping
-        if isinstance(group_key, tuple):
-            continue
-
         for label in lhs_labels:
             row_outlines.append(
                 Outline(
@@ -377,7 +373,7 @@ def selection(axis: Axis, other=False) -> Selection:
 
 def make_highlights(labels: t.Iterable,
                     select: Selection,
-                    anchor='lhs') -> t.List[Mark]:
+                    anchor: Anchor = 'lhs') -> t.List[Mark]:
     '''
     shorthand to make a highlight for each label
     '''

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_01.py
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_01.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs
+ .groupby(['grooming', 'kids'])
+ .max()
+)

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
@@ -1,0 +1,394 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\n(dogs\n .groupby(['grooming', 'kids'])\n .max()\n)\n",
+  "explanation": [
+    {
+      "type": "GroupByCall",
+      "code_step": "(dogs\n .groupby(['grooming', 'kids'])\n .max()\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 31
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "highlight",
+          "select": "column",
+          "anchor": "lhs",
+          "label": "grooming"
+        },
+        {
+          "illustrate": "highlight",
+          "select": "column",
+          "anchor": "lhs",
+          "label": "kids"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "Beagle",
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "Golden Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "Yorkshire Terrier",
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "Bulldog",
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "Boxer",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrameGroupBy",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "Beagle",
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "Golden Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "Yorkshire Terrier",
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "Bulldog",
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "Boxer",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ],
+          "group_data": {
+            "col_names": [
+              "grooming",
+              "kids"
+            ],
+            "groups": [
+              {
+                "name": [
+                  "daily",
+                  "high"
+                ],
+                "labels": [
+                  2
+                ]
+              },
+              {
+                "name": [
+                  "daily",
+                  "low"
+                ],
+                "labels": [
+                  4
+                ]
+              },
+              {
+                "name": [
+                  "weekly",
+                  "high"
+                ],
+                "labels": [
+                  0,
+                  3,
+                  6
+                ]
+              },
+              {
+                "name": [
+                  "weekly",
+                  "medium"
+                ],
+                "labels": [
+                  1,
+                  5
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "AggCall",
+      "code_step": "(dogs\n .groupby(['grooming', 'kids'])\n .max()\n)",
+      "fragment": {
+        "start": {
+          "line": 2,
+          "ch": 1
+        },
+        "end": {
+          "line": 2,
+          "ch": 7
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 2
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "daily",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 4
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "daily",
+              "low"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 0
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 3
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 6
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 1
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "weekly",
+              "medium"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 5
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "weekly",
+              "medium"
+            ]
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "food_cost",
+            "size"
+          ],
+          "row_labels": [
+            [
+              "daily",
+              "high"
+            ],
+            [
+              "daily",
+              "low"
+            ],
+            [
+              "weekly",
+              "high"
+            ],
+            [
+              "weekly",
+              "medium"
+            ]
+          ],
+          "data": [
+            [
+              "Beagle",
+              324.0,
+              "small"
+            ],
+            [
+              "Yorkshire Terrier",
+              324.0,
+              "small"
+            ],
+            [
+              "Labrador Retriever",
+              466.0,
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              466.0,
+              "medium"
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_02.py
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_02.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import io
+
+csv = '''
+breed,grooming,food_cost,kids,size
+Labrador Retriever,weekly,466.0,high,medium
+German Shepherd,weekly,466.0,medium,large
+Beagle,daily,324.0,high,small
+Golden Retriever,weekly,466.0,high,medium
+Yorkshire Terrier,daily,324.0,low,small
+Bulldog,weekly,466.0,medium,medium
+Boxer,weekly,466.0,high,medium
+'''
+
+dogs = pd.read_csv(io.StringIO(csv))
+
+(dogs
+ .groupby(['size', 'grooming', 'kids'])
+ [['food_cost']]
+ .max()
+)

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
@@ -1,0 +1,553 @@
+{
+  "code": "import pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\n(dogs\n .groupby(['size', 'grooming', 'kids'])\n [['food_cost']]\n .max()\n)\n",
+  "explanation": [
+    {
+      "type": "GroupByCall",
+      "code_step": "(dogs\n .groupby(['size', 'grooming', 'kids'])\n [['food_cost']]\n .max()\n)",
+      "fragment": {
+        "start": {
+          "line": 1,
+          "ch": 1
+        },
+        "end": {
+          "line": 1,
+          "ch": 39
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "highlight",
+          "select": "column",
+          "anchor": "lhs",
+          "label": "size"
+        },
+        {
+          "illustrate": "highlight",
+          "select": "column",
+          "anchor": "lhs",
+          "label": "grooming"
+        },
+        {
+          "illustrate": "highlight",
+          "select": "column",
+          "anchor": "lhs",
+          "label": "kids"
+        }
+      ],
+      "data_frame": {
+        "lhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "Beagle",
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "Golden Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "Yorkshire Terrier",
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "Bulldog",
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "Boxer",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrameGroupBy",
+          "col_names": [
+            "breed",
+            "grooming",
+            "food_cost",
+            "kids",
+            "size"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              "Labrador Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "German Shepherd",
+              "weekly",
+              466.0,
+              "medium",
+              "large"
+            ],
+            [
+              "Beagle",
+              "daily",
+              324.0,
+              "high",
+              "small"
+            ],
+            [
+              "Golden Retriever",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ],
+            [
+              "Yorkshire Terrier",
+              "daily",
+              324.0,
+              "low",
+              "small"
+            ],
+            [
+              "Bulldog",
+              "weekly",
+              466.0,
+              "medium",
+              "medium"
+            ],
+            [
+              "Boxer",
+              "weekly",
+              466.0,
+              "high",
+              "medium"
+            ]
+          ],
+          "group_data": {
+            "col_names": [
+              "size",
+              "grooming",
+              "kids"
+            ],
+            "groups": [
+              {
+                "name": [
+                  "large",
+                  "weekly",
+                  "medium"
+                ],
+                "labels": [
+                  1
+                ]
+              },
+              {
+                "name": [
+                  "medium",
+                  "weekly",
+                  "high"
+                ],
+                "labels": [
+                  0,
+                  3,
+                  6
+                ]
+              },
+              {
+                "name": [
+                  "medium",
+                  "weekly",
+                  "medium"
+                ],
+                "labels": [
+                  5
+                ]
+              },
+              {
+                "name": [
+                  "small",
+                  "daily",
+                  "high"
+                ],
+                "labels": [
+                  2
+                ]
+              },
+              {
+                "name": [
+                  "small",
+                  "daily",
+                  "low"
+                ],
+                "labels": [
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "Subscript",
+      "code_step": "(dogs\n .groupby(['size', 'grooming', 'kids'])\n [['food_cost']]\n .max()\n)",
+      "fragment": {
+        "start": {
+          "line": 2,
+          "ch": 1
+        },
+        "end": {
+          "line": 2,
+          "ch": 16
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "outline",
+          "select": "column",
+          "from": {
+            "anchor": "lhs",
+            "label": "food_cost"
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": "food_cost"
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrameGroupBy",
+          "col_names": [
+            "food_cost"
+          ],
+          "row_labels": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "data": [
+            [
+              466.0
+            ],
+            [
+              466.0
+            ],
+            [
+              324.0
+            ],
+            [
+              466.0
+            ],
+            [
+              324.0
+            ],
+            [
+              466.0
+            ],
+            [
+              466.0
+            ]
+          ],
+          "group_data": {
+            "col_names": [
+              "size",
+              "grooming",
+              "kids"
+            ],
+            "groups": [
+              {
+                "name": [
+                  "large",
+                  "weekly",
+                  "medium"
+                ],
+                "labels": [
+                  1
+                ]
+              },
+              {
+                "name": [
+                  "medium",
+                  "weekly",
+                  "high"
+                ],
+                "labels": [
+                  0,
+                  3,
+                  6
+                ]
+              },
+              {
+                "name": [
+                  "medium",
+                  "weekly",
+                  "medium"
+                ],
+                "labels": [
+                  5
+                ]
+              },
+              {
+                "name": [
+                  "small",
+                  "daily",
+                  "high"
+                ],
+                "labels": [
+                  2
+                ]
+              },
+              {
+                "name": [
+                  "small",
+                  "daily",
+                  "low"
+                ],
+                "labels": [
+                  4
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "AggCall",
+      "code_step": "(dogs\n .groupby(['size', 'grooming', 'kids'])\n [['food_cost']]\n .max()\n)",
+      "fragment": {
+        "start": {
+          "line": 3,
+          "ch": 1
+        },
+        "end": {
+          "line": 3,
+          "ch": 7
+        }
+      },
+      "mapping": [
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 1
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "large",
+              "weekly",
+              "medium"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 0
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "medium",
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 3
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "medium",
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 6
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "medium",
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 5
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "medium",
+              "weekly",
+              "medium"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 2
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "small",
+              "daily",
+              "high"
+            ]
+          }
+        },
+        {
+          "illustrate": "outline",
+          "select": "row",
+          "from": {
+            "anchor": "lhs",
+            "label": 4
+          },
+          "to": {
+            "anchor": "rhs",
+            "label": [
+              "small",
+              "daily",
+              "low"
+            ]
+          }
+        }
+      ],
+      "data_frame": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrame",
+          "col_names": [
+            "food_cost"
+          ],
+          "row_labels": [
+            [
+              "large",
+              "weekly",
+              "medium"
+            ],
+            [
+              "medium",
+              "weekly",
+              "high"
+            ],
+            [
+              "medium",
+              "weekly",
+              "medium"
+            ],
+            [
+              "small",
+              "daily",
+              "high"
+            ],
+            [
+              "small",
+              "daily",
+              "low"
+            ]
+          ],
+          "data": [
+            [
+              466.0
+            ],
+            [
+              466.0
+            ],
+            [
+              466.0
+            ],
+            [
+              324.0
+            ],
+            [
+              324.0
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -20,10 +20,13 @@ from pandas.core.groupby.groupby import GroupBy
 Axis = t.Literal['index', 'columns']
 Slicer = t.Literal['loc', 'iloc', None]
 
+# A Label is a value that can go into a pandas Index. It's a tuple of values
+# if we have a multi-index, or a single value otherwise.
+#
 # technically dataframe labels can be all sorts of things...
-# TODO: handle other index dtypes
-Label = t.Union[int, str]
-Labels = t.Union[t.List[int], t.List[str]]
+# TODO: handle other index dtypes, like datetimes
+Label = t.Union[int, str, tuple]
+Labels = t.Union[t.List[int], t.List[str], t.List[tuple]]
 
 HasIndex = t.Union[pd.DataFrame, pd.Series]
 


### PR DESCRIPTION
these examples should work: 

https://github.com/SamLau95/pandas_tutor/blob/e513b9c0b07d460f5a72dd2ccc01a6d1ac3023f3/pandas_tutor/tests/e2e_golden/groupby_multi_01.py#L17-L20

and

https://github.com/SamLau95/pandas_tutor/blob/e513b9c0b07d460f5a72dd2ccc01a6d1ac3023f3/pandas_tutor/tests/e2e_golden/groupby_multi_02.py#L17-L21

since the results have indexes with multiple levels, the `label` key can be a list of values instead of a single value:

https://github.com/SamLau95/pandas_tutor/blob/e513b9c0b07d460f5a72dd2ccc01a6d1ac3023f3/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden#L235-L249