### PR TITLE
change table position JSON spec

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -110,18 +110,126 @@ class RuntimeErrorInChain(RuntimeErrorOutput):
 Explanation = t.List[t.Union[Diagram, ErrorOutput]]
 
 ##############################################################################
+# TablePos
+##############################################################################
+
+# the table we're pointing to
+Anchor = t.Literal['lhs', 'rhs']
+
+# the axis we're pointing to
+Selection = t.Literal['column', 'row']
+
+# the index level we're pointing to. None if index is not multi-level
+IndexLevel = t.Union[None, str, int]
+
+# each TablePos object is serialized as one of these
+TablePosType = t.Literal['axis', 'series', 'label', 'index_level',
+                         'index_name', 'datum']
+
+
+@dataclasses.dataclass
+class TablePos:
+    '''
+    base class that represents a position in a table or series.
+    we use this to point to:
+
+    - an single column or row
+    - a entire series
+    - a single label in the row or column index
+    - an entire level in the column or row index
+    - the name for an index level
+    - a single datum
+    '''
+    # needs to be initialized by subclass
+    type: TablePosType = field(init=False)
+
+    def __post_init__(self):
+        raise NotImplementedError('subclasses need to initialize self.type')
+
+
+@dataclasses.dataclass
+class AxisPos(TablePos):
+    """points to a single column or row for a table"""
+    anchor: Anchor
+    select: Selection
+    label: Label
+
+    def __post_init__(self):
+        self.type = 'axis'
+
+
+@dataclasses.dataclass
+class SeriesPos(TablePos):
+    """points to an entire series"""
+    anchor: Anchor
+    label: Label = field(default='pandas.Series', init=False)
+
+    def __post_init__(self):
+        self.type = 'series'
+
+
+@dataclasses.dataclass
+class LabelPos(TablePos):
+    """
+    points to a single label for a column or row. used for functions like
+    rename()
+    """
+    anchor: Anchor
+    select: Selection
+    label: Label
+    level: IndexLevel = None
+
+    def __post_init__(self):
+        self.type = 'label'
+
+
+@dataclasses.dataclass
+class IndexLevelPos(TablePos):
+    """points to a single level for the index of the column or row labels"""
+    anchor: Anchor
+    select: Selection
+    level: IndexLevel = None
+
+    def __post_init__(self):
+        self.type = 'index_level'
+
+
+@dataclasses.dataclass
+class IndexNamePos(TablePos):
+    """
+    points to the name for a level of the index of the column or row labels.
+    used for functions like rename_axis() which renames index levels
+    """
+    anchor: Anchor
+    select: Selection
+    level: IndexLevel = None
+
+    def __post_init__(self):
+        self.type = 'index_name'
+
+
+@dataclasses.dataclass
+class DatumPos(TablePos):
+    """points to a single datum in the table"""
+    anchor: Anchor
+    column: Label
+    row: Label
+
+    def __post_init__(self):
+        self.type = 'datum'
+
+
+##############################################################################
 # Mark
 ##############################################################################
 
-Selection = t.Literal['column', 'row']
-Anchor = t.Literal['lhs', 'rhs']
+# each Mark object is serialized as one of these
 MarkType = t.Literal['highlight', 'outline', 'crossout']
 
 
 @dataclasses.dataclass
 class Mark:
     illustrate: MarkType = field(init=False)
-    select: Selection
 
     def __post_init__(self):
         raise NotImplementedError(
@@ -130,8 +238,8 @@ class Mark:
 
 @dataclasses.dataclass
 class Highlight(Mark):
-    anchor: Anchor
-    label: Label
+    '''rendered as a border'''
+    pos: TablePos
 
     def __post_init__(self):
         self.illustrate = 'highlight'
@@ -139,6 +247,7 @@ class Highlight(Mark):
 
 @dataclasses.dataclass
 class Outline(Mark):
+    '''rendered as an arrow'''
     # from is a Python keyword!
     from_: TablePos
     to: TablePos
@@ -148,15 +257,12 @@ class Outline(Mark):
 
 
 @dataclasses.dataclass
-class CrossOut(Outline):
+class CrossOut(Mark):
+    '''rendered as strikethroughs'''
+    pos: TablePos
+
     def __post_init__(self):
         self.illustrate = 'crossout'
-
-
-@dataclasses.dataclass
-class TablePos:
-    anchor: Anchor
-    label: Label
 
 
 ##############################################################################

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -327,7 +327,7 @@ def mark_for_subscript_into_series(
     # df.iloc[:, 0]
     col = args.get('slice2_values')
     if isinstance(col, (str, int)):
-        col = util.positions_to_labels(
+        label = util.positions_to_labels(
             col,
             df=before_df,
             slicer=step.slicer,
@@ -335,7 +335,7 @@ def mark_for_subscript_into_series(
         )
         return [
             *cols_used_for_filter,
-            Outline(from_=lhs('column', col), to=rhs_series()),
+            Outline(from_=lhs('column', label), to=rhs_series()),
             *diff_rows(before_df,
                        after_df,
                        only_if_diff=(len(cols_used_for_filter) == 0)),

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -6,20 +6,25 @@ import typing as t
 import pandas as pd
 
 from . import util
-from .diagram import (Anchor, CrossOut, Highlight, Mark, Outline, Selection,
-                      TablePos)
+from .diagram import (Anchor, AxisPos, CrossOut, Highlight, LabelPos, Mark,
+                      Outline, Selection, SeriesPos)
 from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStep,
                           DropCall, EvalError, GroupByCall, HeadCall,
                           PassThroughCall, RenameCall, SortValuesCall,
-                          SubsComparison, Subscript, SubscriptEl, TailCall)
+                          SubsComparison, Subscript, SubscriptEl, TailCall,
+                          UnstackCall)
 from .run import (Arg, DFResult, EvalResult, GroupbyResult,
                   SeriesGroupbyResult, SeriesResult)
 
 
 # step comes from after.step, but we pull it out here to help with
-# the type checker
+# the type checker.
 def make_marks(step: ChainStep, before: EvalResult,
                after: EvalResult) -> t.List[Mark]:
+    '''
+    computes the marks for a given step by dispatching to the right marks
+    function. returns empty list if we don't know how to make marks.
+    '''
     if isinstance(step, EvalError):
         return no_marks()
     elif isinstance(step, PassThroughCall):
@@ -40,6 +45,8 @@ def make_marks(step: ChainStep, before: EvalResult,
         return mark_for_groupby(step, before, after)
     elif isinstance(step, AggCall):
         return mark_for_agg(step, before, after)
+    elif isinstance(step, UnstackCall):
+        return mark_for_unstack(step, before, after)
     elif isinstance(step, Subscript):
         return mark_for_subscript(step, before, after)
     else:
@@ -104,7 +111,8 @@ def mark_for_rename(step: RenameCall, before: EvalResult,
     select = selection(step.axis)
 
     return [
-        Outline(select=select, from_=lhs(old), to=rhs(new))
+        Outline(from_=LabelPos('lhs', select, old),
+                to=LabelPos('rhs', select, new))
         for old, new in mapping.items()
     ]
 
@@ -176,13 +184,20 @@ def mark_for_agg(step: AggCall, before: EvalResult,
     for group_key, lhs_labels in groups.items():
         for label in lhs_labels:
             row_outlines.append(
+                # TODO: get selection from groupby instead of hard-coding 'row'
                 Outline(
-                    select='row',  # TODO: get selection from groupby
-                    from_=lhs(label),
-                    to=rhs(group_key),
+                    from_=lhs('row', label),
+                    to=rhs('row', group_key),
                 ))
 
     return row_outlines
+
+
+# for unstack, we're going to color the
+# counts.unstack(level=-1, fill_value=0)
+def mark_for_unstack(step: UnstackCall, before: EvalResult,
+                     after: EvalResult) -> t.List[Mark]:
+    return []
 
 
 # handler for all subscripts, like:
@@ -272,13 +287,11 @@ def mark_for_subscript_into_series(
 
     # df['kids']
     if step.slicer is None:
-        maybe_col = args.get('slice1_values')
-        if not isinstance(maybe_col, (str, int)):
+        col = args.get('slice1_values')
+        if not isinstance(col, (str, int)):
             return []
 
-        return [
-            Outline(select='column', from_=lhs(maybe_col), to=rhs_series())
-        ]
+        return [Outline(from_=lhs('column', col), to=rhs_series())]
 
     # df.loc[df["email"] > "s", "web"]
     # df.loc[:, df.iloc[0] % 2 == 0]
@@ -305,24 +318,24 @@ def mark_for_subscript_into_series(
 
         return [
             *rows_used_for_filter,
-            Outline(select='row', from_=lhs(row), to=rhs_series()),
+            Outline(from_=lhs('row', row), to=rhs_series()),
             # when slicing a row out of dataframe, the resulting series has
             # the df's column labels as the index. this means that the labels
             # are "transposed" so we don't draw arrows for this case.
         ]
 
     # df.iloc[:, 0]
-    maybe_col = args.get('slice2_values')
-    if isinstance(maybe_col, (str, int)):
+    col = args.get('slice2_values')
+    if isinstance(col, (str, int)):
         col = util.positions_to_labels(
-            maybe_col,
+            col,
             df=before_df,
             slicer=step.slicer,
             axis='columns',
         )
         return [
             *cols_used_for_filter,
-            Outline(select='column', from_=lhs(col), to=rhs_series()),
+            Outline(from_=lhs('column', col), to=rhs_series()),
             *diff_rows(before_df,
                        after_df,
                        only_if_diff=(len(cols_used_for_filter) == 0)),
@@ -375,12 +388,9 @@ def make_highlights(labels: t.Iterable,
                     select: Selection,
                     anchor: Anchor = 'lhs') -> t.List[Mark]:
     '''
-    shorthand to make a highlight for each label
+    shorthand to make a highlight for each column/row in labels
     '''
-    return [
-        Highlight(label=label, select=select, anchor=anchor)
-        for label in labels
-    ]
+    return [Highlight(AxisPos(anchor, select, label)) for label in labels]
 
 
 def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
@@ -388,7 +398,7 @@ def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     shorthand when index values don't change, which is most of the time
     '''
     return [
-        Outline(select=select, from_=lhs(label), to=rhs(label))
+        Outline(from_=lhs(select, label), to=rhs(select, label))
         for label in labels
     ]
 
@@ -397,28 +407,24 @@ def make_crossouts(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     '''
     shorthand for crossouts
     '''
-    # we haven't implemented arg anchors yet, so use a dummy value for now
-    dummy_arg_anchor = {'anchor': 'arg', 'index': 0}
-    return [
-        CrossOut(
-            select=select,
-            from_=dummy_arg_anchor,  # type: ignore
-            to=lhs(label),
-        ) for label in labels
-    ]
+    return [CrossOut(pos=lhs(select, label)) for label in labels]
 
 
-def lhs(label):
-    return TablePos('lhs', label)
+def lhs(select: Selection, label: util.Label) -> AxisPos:
+    '''shorthand for a column/row in lhs'''
+    return AxisPos('lhs', select, label)
 
 
-def rhs(label):
-    return TablePos('rhs', label)
+def rhs(select: Selection, label: util.Label) -> AxisPos:
+    '''shorthand for a column/row in rhs'''
+    return AxisPos('rhs', select, label)
 
 
-def lhs_series():
-    return lhs('pandas.Series')
+def lhs_series() -> SeriesPos:
+    '''shorthand for the lhs series'''
+    return SeriesPos('lhs')
 
 
-def rhs_series():
-    return rhs('pandas.Series')
+def rhs_series() -> SeriesPos:
+    '''shorthand for the rhs series'''
+    return SeriesPos('rhs')

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -28,7 +28,8 @@ from .parse_nodes import (AggCall, ApplyCall, AssignCall, Axis, ChainStatement,
                           ParseResult, ParsedModule, ParseSyntaxError,
                           PassThroughCall, RawCode, RenameCall, SortValuesCall,
                           StartOfChain, SubsComparison, Subscript, SubscriptEl,
-                          SubsEval, SubsSlice, TailCall, VerbatimStatement)
+                          SubsEval, SubsSlice, TailCall, UnstackCall,
+                          VerbatimStatement)
 from .util import CodePosition, CodeRange
 from . import util
 
@@ -89,10 +90,11 @@ is_head_or_tail = fn_matcher('head') | fn_matcher('tail')
 is_groupby = fn_matcher('groupby')
 is_apply = fn_matcher('apply')
 is_assign = fn_matcher('assign')
+is_unstack = fn_matcher('unstack')
 
 # make sure to update this whenever we add a new call to the section above
 is_parsed_call = (is_sort_values | is_drop | is_rename | is_head_or_tail
-                  | is_groupby | is_apply | is_assign)
+                  | is_groupby | is_apply | is_assign | is_unstack)
 
 is_loc_iloc = m.Subscript(value=m.Attribute(attr=m.Name('loc')
                                             | m.Name('iloc')))
@@ -406,6 +408,23 @@ class ChainParser(ParserBase):
                 if axis_arg is not None else 'index')
 
         node = self.make_call_node(GroupByCall, cst_node, axis=axis)
+        self._append(node)
+
+    @m.leave(is_unstack)
+    def make_unstack(self, cst_node):
+        level_expr = get_arg_by_position_or_keyword(cst_node.args, 0, 'level')
+        fill_value_expr = get_arg_by_position_or_keyword(
+            cst_node.args, 1, 'fill_value')
+
+        if level_expr is not None:
+            level_expr = self.code_for(level_expr.value)
+        if fill_value_expr is not None:
+            fill_value_expr = self.code_for(fill_value_expr.value)
+
+        node = self.make_call_node(UnstackCall,
+                                   cst_node,
+                                   level_expr=level_expr,
+                                   fill_value_expr=fill_value_expr)
         self._append(node)
 
     def make_call_node(self, cls: t.Type[T], cst_node: cst.Call,

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -433,6 +433,7 @@ class SubscriptParser(ParserBase):
         if not isinstance(node, cst.Subscript):
             warn('used SubscriptParser to visit a non-subscript: '
                  f'{self.code_for(node)}')
+            return False
 
         slicer: t.Optional[str] = None
         if m.matches(node, is_loc_iloc):
@@ -562,7 +563,7 @@ class LoggingVisitor(m.MatcherDecoratableVisitor):
         if m.matches(node, whitespace):
             return False
         if self.cst_root is None:
-            self.cst_root = node
+            self.cst_root = t.cast(cst.Module, node)
             return True
 
         self.log(node)

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -230,6 +230,21 @@ class DropCall(Call):
     row_expr: t.Optional[RawCode] = evals_into('row_labels')
 
 
+@dataclasses.dataclass
+class UnstackCall(Call):
+    '''
+    counts.unstack()
+    counts.unstack(level=1)
+    counts.unstack(level=[1, 2])
+    counts.unstack(level=-1, fill_value=0)
+    '''
+    fn_name = 'unstack'
+
+    level_expr: t.Optional[RawCode] = evals_into('level')
+    fill_value_expr: t.Optional[RawCode] = evals_into('fill_value')
+
+
+
 ##############################################################################
 # Subscripts
 ##############################################################################

--- a/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
@@ -17,85 +17,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "breed"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }
@@ -153,85 +155,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "daily"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "daily"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
@@ -17,21 +17,30 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "daily"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "daily"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "yearly"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "yearly"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "s"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "s"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "test"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "test"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "daily"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "daily"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
@@ -17,25 +17,19 @@
       "mapping": [
         {
           "illustrate": "crossout",
-          "select": "column",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "type"
           }
         },
         {
           "illustrate": "crossout",
-          "select": "column",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "price"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
@@ -17,25 +17,19 @@
       "mapping": [
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "Labrador Retriever"
           }
         },
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "Beagle"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
@@ -17,25 +17,19 @@
       "mapping": [
         {
           "illustrate": "crossout",
-          "select": "column",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "type"
           }
         },
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           }
         }

--- a/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
@@ -17,13 +17,10 @@
       "mapping": [
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           }
         }

--- a/pandas_tutor/tests/e2e_golden/drop_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_series.py.golden
@@ -17,25 +17,19 @@
       "mapping": [
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "Labrador Retriever"
           }
         },
         {
           "illustrate": "crossout",
-          "select": "row",
-          "from": {
-            "anchor": "arg",
-            "index": 0
-          },
-          "to": {
+          "pos": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "Beagle"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
@@ -17,91 +17,115 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "kids"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "kids"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/filter_all_match.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_all_match.py.golden
@@ -17,91 +17,115 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "food_cost"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "food_cost"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
@@ -17,33 +17,42 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "b"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "b"
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "d"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "d"
           }
         },
         {
           "illustrate": "highlight",
-          "select": "row",
-          "anchor": "lhs",
-          "label": "one"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "row",
+            "label": "one"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
@@ -17,55 +17,69 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "email"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "email"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "web"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         }

--- a/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
@@ -17,18 +17,23 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "row",
-          "anchor": "lhs",
-          "label": "two"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "row",
+            "label": "two"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "one"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
@@ -17,25 +17,34 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "Count"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "Count"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "Sex"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "Sex"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         }

--- a/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
@@ -17,25 +17,34 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "Count"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "Count"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "Sex"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "Sex"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         }

--- a/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
@@ -17,55 +17,70 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "Count"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "Count"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         }

--- a/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "breed"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "size"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "size"
+          }
         }
       ],
       "data_frame": {
@@ -236,12 +239,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "food_cost"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }
@@ -328,85 +333,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "large"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "medium"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "medium"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "medium"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "medium"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "small"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "small"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/groupby_manual.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_manual.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": null
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": null
+          }
         }
       ],
       "data_frame": {
@@ -161,37 +164,46 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "pg"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "sam"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "sam"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "grooming"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "grooming"
+          }
         }
       ],
       "data_frame": {
@@ -229,85 +232,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "daily"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "daily"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
@@ -17,15 +17,21 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "grooming"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "grooming"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "kids"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "kids"
+          }
         }
       ],
       "data_frame": {
@@ -254,13 +260,16 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "daily",
               "high"
@@ -269,13 +278,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "daily",
               "low"
@@ -284,13 +296,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "weekly",
               "high"
@@ -299,13 +314,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "weekly",
               "high"
@@ -314,13 +332,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "weekly",
               "high"
@@ -329,13 +350,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "weekly",
               "medium"
@@ -344,13 +368,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "weekly",
               "medium"

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
@@ -17,21 +17,30 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "size"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "size"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "grooming"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "grooming"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "kids"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "kids"
+          }
         }
       ],
       "data_frame": {
@@ -274,13 +283,16 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "food_cost"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "food_cost"
           }
         }
@@ -414,13 +426,16 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "large",
               "weekly",
@@ -430,13 +445,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "medium",
               "weekly",
@@ -446,13 +464,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "medium",
               "weekly",
@@ -462,13 +483,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "medium",
               "weekly",
@@ -478,13 +502,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "medium",
               "weekly",
@@ -494,13 +521,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "small",
               "daily",
@@ -510,13 +540,16 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "small",
               "daily",

--- a/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "grooming"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "grooming"
+          }
         }
       ],
       "data_frame": {
@@ -229,85 +232,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "daily"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "daily"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "weekly"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/groupby_with_groupers_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_groupers_01.py.golden
@@ -17,15 +17,21 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "second"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "second"
+          }
         },
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "A"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
         }
       ],
       "data_frame": {
@@ -307,16 +313,19 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "bar",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "one",
               1
@@ -325,16 +334,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "baz",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "one",
               1
@@ -343,16 +355,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "one",
               2
@@ -361,16 +376,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "qux",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "one",
               3
@@ -379,16 +397,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "bar",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "two",
               1
@@ -397,16 +418,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "baz",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "two",
               1
@@ -415,16 +439,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "two",
               2
@@ -433,16 +460,19 @@
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "qux",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": [
               "two",
               3

--- a/pandas_tutor/tests/e2e_golden/groupby_with_level_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_level_01.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "A"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
         }
       ],
       "data_frame": {
@@ -266,121 +269,145 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "bar",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "bar"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "bar",
               "three"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "bar"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "bar",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "bar"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "foo"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "foo"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "two"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "foo"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "one"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "foo"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": [
               "foo",
               "three"
             ]
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "foo"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "date"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "date"
+          }
         }
       ],
       "data_frame": {
@@ -228,97 +231,121 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "11"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "11"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "11"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "11"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "12"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "12"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "12"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 7
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "12"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/head_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_01.py.golden
@@ -17,37 +17,46 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         }

--- a/pandas_tutor/tests/e2e_golden/head_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_series_01.py.golden
@@ -17,25 +17,31 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "a"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "a"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "b"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "b"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/homepage_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/homepage_01.py.golden
@@ -17,199 +17,250 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "size"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "size"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 10
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 10
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 11
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 11
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 13
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 13
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 16
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 16
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 19
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 19
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 20
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 20
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 22
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 22
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 24
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 24
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 26
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 26
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 31
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 31
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 32
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 32
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 33
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 33
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 35
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 35
           }
         }
@@ -729,199 +780,250 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "group"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "group"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 10
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 10
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 11
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 11
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 13
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 13
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 16
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 16
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 19
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 19
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 20
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 20
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 22
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 22
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 24
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 24
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 26
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 26
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 31
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 31
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 32
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 32
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 33
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 33
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 35
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 35
           }
         }
@@ -1098,9 +1200,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "group"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "group"
+          }
         }
       ],
       "data_frame": {
@@ -1340,193 +1445,241 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 19
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "herding"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 24
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "herding"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "hound"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "hound"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 35
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "hound"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 33
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "non-sporting"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 26
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "sporting"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 11
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "terrier"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 31
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "terrier"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 10
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 13
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 16
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 20
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 22
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 32
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "toy"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "breed"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
@@ -186,12 +186,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "Beagle"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
@@ -17,73 +17,91 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Sex"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Sex"
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Count"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Count"
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Year"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Year"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         }

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
@@ -17,37 +17,46 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "breed"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "food_cost"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/loc_nested.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_nested.py.golden
@@ -17,73 +17,91 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_of_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_of_series_01.py.golden
@@ -17,25 +17,31 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "b"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "b"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "d"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "d"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
@@ -17,85 +17,106 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Name"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Name"
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Count"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Count"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
@@ -17,25 +17,31 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Name"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Name"
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "Count"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "column",
             "label": "Count"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
@@ -17,91 +17,115 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "kids"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "kids"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }
@@ -285,73 +309,91 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         }

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
@@ -17,91 +17,115 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "kids"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "kids"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }
@@ -285,49 +309,61 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/memory_cap_ok.py.golden
+++ b/pandas_tutor/tests/e2e_golden/memory_cap_ok.py.golden
@@ -17,61 +17,76 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 23218
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 23218
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 20731
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 20731
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 39555
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 39555
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 147506
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 147506
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 314215
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 314215
           }
         }

--- a/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
@@ -17,67 +17,85 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "two"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "two"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "a"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "a"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "c"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "c"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "e"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "e"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "f"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "f"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "h"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "h"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
@@ -17,26 +17,36 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": "breed"
+            "select": "column",
+            "label": "breed",
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "b"
+            "select": "column",
+            "label": "b",
+            "level": null
           }
         },
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": "food_cost"
+            "select": "column",
+            "label": "food_cost",
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "cost"
+            "select": "column",
+            "label": "cost",
+            "level": null
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/rename_fn.py
+++ b/pandas_tutor/tests/e2e_golden/rename_fn.py
@@ -1,4 +1,5 @@
 # Tests rename with a function
+# TODO: we don't create marks for this case right now
 import pandas as pd
 import io
 

--- a/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
@@ -1,5 +1,5 @@
 {
-  "code": "# Tests rename with a function\nimport pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\n\ndef renamer(label: str):\n    return label.upper()\n\n\ndogs.rename(columns=renamer)\n",
+  "code": "# Tests rename with a function\n# TODO: we don't create marks for this case right now\nimport pandas as pd\nimport io\n\ncsv = '''\nbreed,grooming,food_cost,kids,size\nLabrador Retriever,weekly,466.0,high,medium\nGerman Shepherd,weekly,466.0,medium,large\nBeagle,daily,324.0,high,small\nGolden Retriever,weekly,466.0,high,medium\nYorkshire Terrier,daily,324.0,low,small\nBulldog,weekly,466.0,medium,medium\nBoxer,weekly,466.0,high,medium\n'''\n\ndogs = pd.read_csv(io.StringIO(csv))\n\n\ndef renamer(label: str):\n    return label.upper()\n\n\ndogs.rename(columns=renamer)\n",
   "explanation": [
     {
       "type": "RenameCall",

--- a/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
@@ -17,26 +17,36 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": 0
+            "select": "row",
+            "label": 0,
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "hello"
+            "select": "row",
+            "label": "hello",
+            "level": null
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": 1
+            "select": "row",
+            "label": 1,
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "world"
+            "select": "row",
+            "label": "world",
+            "level": null
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/rename_series_dict.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_series_dict.py.golden
@@ -17,26 +17,36 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": 0
+            "select": "row",
+            "label": 0,
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "hello"
+            "select": "row",
+            "label": "hello",
+            "level": null
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "label",
             "anchor": "lhs",
-            "label": 1
+            "select": "row",
+            "label": 1,
+            "level": null
           },
           "to": {
+            "type": "label",
             "anchor": "rhs",
-            "label": "world"
+            "select": "row",
+            "label": "world",
+            "level": null
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "food_cost"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "breed"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }

--- a/pandas_tutor/tests/e2e_golden/slice_double.py.golden
+++ b/pandas_tutor/tests/e2e_golden/slice_double.py.golden
@@ -17,12 +17,14 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "column",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "column",
             "label": "duration"
           },
           "to": {
+            "type": "series",
             "anchor": "rhs",
             "label": "pandas.Series"
           }
@@ -313,61 +315,76 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 10
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 10
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 11
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 11
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 12
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 12
           }
         }

--- a/pandas_tutor/tests/e2e_golden/sort_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_series.py.golden
@@ -17,49 +17,61 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "a"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "a"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "b"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "b"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "c"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "c"
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": "d"
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": "d"
           }
         }

--- a/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
@@ -17,127 +17,160 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "Name"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "Name"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 7
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 7
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         }

--- a/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
@@ -17,127 +17,160 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "Name"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "Name"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 7
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 7
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         }

--- a/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
@@ -17,127 +17,160 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "Name"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "Name"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 7
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 7
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         }
@@ -347,127 +380,160 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "rhs",
-          "label": "Count"
+          "pos": {
+            "type": "axis",
+            "anchor": "rhs",
+            "select": "column",
+            "label": "Count"
+          }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 9
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 9
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 7
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 7
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 3
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 1
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 2
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 8
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 8
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4
           }
         }

--- a/pandas_tutor/tests/e2e_golden/tail_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_01.py.golden
@@ -17,25 +17,31 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/e2e_golden/tail_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_series_01.py.golden
@@ -17,25 +17,31 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 5
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 5
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 6
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 6
           }
         }

--- a/pandas_tutor/tests/misc/unstack_01.py
+++ b/pandas_tutor/tests/misc/unstack_01.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import io
+
+csv = '''
+Name,Sex,Count,Year
+Liam,M,19659,2020
+Noah,M,18252,2020
+Oliver,M,14147,2020
+Emma,F,15581,2020
+Ava,F,13084,2020
+Charlotte,F,13003,2020
+Liam,M,20555,2019
+Noah,M,19097,2019
+Oliver,M,13929,2019
+Emma,F,17155,2019
+Ava,F,14474,2019
+Sophia,F,13753,2019
+'''
+
+df = pd.read_csv(io.StringIO(csv))
+counts = (df.groupby(['Year', 'Sex'])['Count'].max())
+
+counts.unstack()

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "b"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "b"
+          }
         }
       ],
       "data_frame": {

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_with_na.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_with_na.py.golden
@@ -17,9 +17,12 @@
       "mapping": [
         {
           "illustrate": "highlight",
-          "select": "column",
-          "anchor": "lhs",
-          "label": "c"
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "c"
+          }
         }
       ],
       "data_frame": {
@@ -178,61 +181,76 @@
       "mapping": [
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 3
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": -5.0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 1
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4.0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 2
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": 4.0
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 0
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": null
           }
         },
         {
           "illustrate": "outline",
-          "select": "row",
           "from": {
+            "type": "axis",
             "anchor": "lhs",
+            "select": "row",
             "label": 4
           },
           "to": {
+            "type": "axis",
             "anchor": "rhs",
+            "select": "row",
             "label": null
           }
         }


### PR DESCRIPTION
**backwards-incompatible changes to all rendered marks!**

before, our JSON spec could only point to entire columns or rows of a dataframe. but in order to implement marks for stack, unstack, reset_index, pivot, and melt, we need a way to reference index levels and individual cells within a dataframe. this PR changes the way table positions are rendered into JSON to support this. 

the new JSON spec for table positions:

https://github.com/SamLau95/pandas_tutor/blob/5d25ed633ca3c5e4a96b9e180efe3500180b5e80/pandas_tutor/diagram.py#L126-L220

the new JSON spec for marks:

https://github.com/SamLau95/pandas_tutor/blob/5d25ed633ca3c5e4a96b9e180efe3500180b5e80/pandas_tutor/diagram.py#L239-L266

as an example, head() calls used to look like:

https://github.com/SamLau95/pandas_tutor/blob/136834e2e90aba67adbed8bde582e946979a6868/pandas_tutor/tests/e2e_golden/head_01.py.golden#L17-L32

now, they look like:

https://github.com/SamLau95/pandas_tutor/blob/44ae0444414fa80686cf2469cac724b9198dde25/pandas_tutor/tests/e2e_golden/head_01.py.golden#L17-L32