### PR TITLE
rename marks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "tests",
+      "type": "shell",
+      "command": "make typecheck test",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -56,11 +56,8 @@ class Diagram:
     type: str
     code_step: str
     fragment: CodeRange
-    mapping: t.List[Mark]
-
-    # although we call this data_frame, technically it can hold any type of
-    # data, like series or groupbys
-    data_frame: DataPair
+    marks: t.List[Mark]
+    data: DataPair
 
 
 @dataclasses.dataclass
@@ -236,12 +233,14 @@ class DatumPos(TablePos):
 ##############################################################################
 
 # each Mark object is serialized as one of these
-MarkType = t.Literal["highlight", "outline", "crossout"]
+MarkType = t.Literal["using", "map", "drop"]
 
 
 @dataclasses.dataclass
 class Mark:
-    illustrate: MarkType = field(init=False)
+    """base class, don't use directly"""
+
+    type: MarkType = field(init=False)
 
     def __post_init__(self):
         raise NotImplementedError(
@@ -250,35 +249,35 @@ class Mark:
 
 
 @dataclasses.dataclass
-class Highlight(Mark):
-    """rendered as a border"""
+class Using(Mark):
+    """represents the data we used to perform an operation"""
 
     pos: TablePos
 
     def __post_init__(self):
-        self.illustrate = "highlight"
+        self.type = "using"
 
 
 @dataclasses.dataclass
-class Outline(Mark):
-    """rendered as an arrow"""
+class Map(Mark):
+    """represents data copied or mapped from lhs to rhs"""
 
     # from is a Python keyword!
     from_: TablePos
     to: TablePos
 
     def __post_init__(self):
-        self.illustrate = "outline"
+        self.type = "map"
 
 
 @dataclasses.dataclass
-class CrossOut(Mark):
-    """rendered as strikethroughs"""
+class Drop(Mark):
+    """represents data explicitly removed from the table"""
 
     pos: TablePos
 
     def __post_init__(self):
-        self.illustrate = "crossout"
+        self.type = "drop"
 
 
 ##############################################################################

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -9,12 +9,12 @@ from . import util
 from .diagram import (
     Anchor,
     AxisPos,
-    CrossOut,
-    Highlight,
+    Drop,
+    Using,
     IndexLevelPos,
     LabelPos,
     Mark,
-    Outline,
+    Map,
     Selection,
     SeriesPos,
 )
@@ -152,9 +152,7 @@ def mark_for_rename(
     select = selection(step.axis)
 
     return [
-        Outline(
-            from_=LabelPos("lhs", select, old), to=LabelPos("rhs", select, new)
-        )
+        Map(from_=LabelPos("lhs", select, old), to=LabelPos("rhs", select, new))
         for old, new in mapping.items()
     ]
 
@@ -233,7 +231,7 @@ def mark_for_agg(
         for label in lhs_labels:
             row_outlines.append(
                 # TODO: get selection from groupby instead of hard-coding 'row'
-                Outline(
+                Map(
                     from_=lhs("row", label),
                     to=rhs("row", group_key),
                 )
@@ -264,9 +262,7 @@ def mark_for_reset_index(
     ]
 
     if args.get("drop", False):
-        return [
-            CrossOut(IndexLevelPos("lhs", "column", level)) for level in levels
-        ]
+        return [Drop(IndexLevelPos("lhs", "column", level)) for level in levels]
 
     # recreating the pandas defaults for unnamed index levels
     names: t.List[str]
@@ -280,7 +276,7 @@ def mark_for_reset_index(
         names = [default] if df.index.name is None else [df.index.name]
 
     return [
-        Outline(
+        Map(
             IndexLevelPos("lhs", "column", level),
             rhs("column", names[level]),
         )
@@ -394,7 +390,7 @@ def mark_for_subscript_into_series(
         if not isinstance(col, (str, int)):
             return []
 
-        return [Outline(from_=lhs("column", col), to=rhs_series())]
+        return [Map(from_=lhs("column", col), to=rhs_series())]
 
     # df.loc[df["email"] > "s", "web"]
     # df.loc[:, df.iloc[0] % 2 == 0]
@@ -423,7 +419,7 @@ def mark_for_subscript_into_series(
 
         return [
             *rows_used_for_filter,
-            Outline(from_=lhs("row", row), to=rhs_series()),
+            Map(from_=lhs("row", row), to=rhs_series()),
             # when slicing a row out of dataframe, the resulting series has
             # the df's column labels as the index. this means that the labels
             # are "transposed" so we don't draw arrows for this case.
@@ -440,7 +436,7 @@ def mark_for_subscript_into_series(
         )
         return [
             *cols_used_for_filter,
-            Outline(from_=lhs("column", label), to=rhs_series()),
+            Map(from_=lhs("column", label), to=rhs_series()),
             *diff_rows(
                 before_df,
                 after_df,
@@ -497,7 +493,7 @@ def make_highlights(
     """
     shorthand to make a highlight for each column/row in labels
     """
-    return [Highlight(AxisPos(anchor, select, label)) for label in labels]
+    return [Using(AxisPos(anchor, select, label)) for label in labels]
 
 
 def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
@@ -505,8 +501,7 @@ def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     shorthand when index values don't change, which is most of the time
     """
     return [
-        Outline(from_=lhs(select, label), to=rhs(select, label))
-        for label in labels
+        Map(from_=lhs(select, label), to=rhs(select, label)) for label in labels
     ]
 
 
@@ -514,7 +509,7 @@ def make_crossouts(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     """
     shorthand for crossouts
     """
-    return [CrossOut(pos=lhs(select, label)) for label in labels]
+    return [Drop(pos=lhs(select, label)) for label in labels]
 
 
 def lhs(select: Selection, label: util.Label) -> AxisPos:

--- a/pandas_tutor/serialize.py
+++ b/pandas_tutor/serialize.py
@@ -78,8 +78,8 @@ def serialize_single(result: EvalResult) -> Explanation:
             type=result.step.type_,
             code_step=result.step.code,
             fragment=result.fragment,
-            mapping=[],
-            data_frame=DataPair(lhs=serialize_step_val(result), rhs="no_rhs"),
+            marks=[],
+            data=DataPair(lhs=serialize_step_val(result), rhs="no_rhs"),
         )
     ]
 
@@ -108,8 +108,8 @@ def serialize_pair(
         type=step.type_,
         code_step=step.code,
         fragment=after.fragment,
-        mapping=marks,
-        data_frame=df_pair,
+        marks=marks,
+        data=df_pair,
     )
 
 

--- a/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_df_rows.py.golden
@@ -14,9 +14,9 @@
           "ch": 24
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -91,7 +91,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -106,7 +106,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -121,7 +121,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/apply_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 14
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -152,9 +152,9 @@
           "ch": 12
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -169,7 +169,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -184,7 +184,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -199,7 +199,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -214,7 +214,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -229,7 +229,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -244,7 +244,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -259,7 +259,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",

--- a/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_lambda.py.golden
@@ -14,9 +14,9 @@
           "ch": 47
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_multi.py.golden
@@ -14,9 +14,9 @@
           "ch": 35
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -34,7 +34,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -43,7 +43,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_single_val.py.golden
@@ -14,9 +14,9 @@
           "ch": 28
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/assign_with_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 38
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/df_itself.py.golden
+++ b/pandas_tutor/tests/e2e_golden/df_itself.py.golden
@@ -14,8 +14,8 @@
           "ch": 4
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_columns.py.golden
@@ -14,9 +14,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows.py.golden
@@ -14,9 +14,9 @@
           "ch": 40
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_and_columns.py.golden
@@ -14,9 +14,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_rows_index.py.golden
@@ -14,9 +14,9 @@
           "ch": 26
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/drop_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/drop_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 40
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/error_runtime_in_chain_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 21
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_all_match.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_all_match.py.golden
@@ -14,9 +14,9 @@
           "ch": 27
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_cols.py.golden
@@ -14,9 +14,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 32
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -39,7 +39,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -54,7 +54,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -69,7 +69,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -84,7 +84,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_into_series_row.py.golden
@@ -14,9 +14,9 @@
           "ch": 34
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -39,7 +39,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi.py.golden
@@ -14,9 +14,9 @@
           "ch": 46
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -49,7 +49,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_multi_loc.py.golden
@@ -14,9 +14,9 @@
           "ch": 50
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -49,7 +49,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/filter_simple.py.golden
@@ -14,9 +14,9 @@
           "ch": 23
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/fragment_test_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 20
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -78,8 +78,8 @@
           "ch": 12
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",
@@ -106,8 +106,8 @@
           "ch": 21
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",

--- a/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_into_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 17
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -236,9 +236,9 @@
           "ch": 14
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -252,7 +252,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "SeriesGroupBy",
@@ -330,9 +330,9 @@
           "ch": 8
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -347,7 +347,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -362,7 +362,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -377,7 +377,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -392,7 +392,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -407,7 +407,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -422,7 +422,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -437,7 +437,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",

--- a/pandas_tutor/tests/e2e_golden/groupby_manual.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_manual.py.golden
@@ -14,9 +14,9 @@
           "ch": 34
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -161,9 +161,9 @@
           "ch": 41
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -178,7 +178,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -193,7 +193,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -208,7 +208,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_max.py.golden
@@ -14,9 +14,9 @@
           "ch": 21
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -229,9 +229,9 @@
           "ch": 7
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -246,7 +246,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -261,7 +261,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -276,7 +276,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -291,7 +291,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -306,7 +306,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -321,7 +321,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -336,7 +336,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 31
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -257,9 +257,9 @@
           "ch": 7
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -277,7 +277,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -295,7 +295,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -313,7 +313,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -331,7 +331,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -349,7 +349,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -367,7 +367,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -385,7 +385,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_multi_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 39
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -43,7 +43,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -280,9 +280,9 @@
           "ch": 16
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -297,7 +297,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrameGroupBy",
@@ -423,9 +423,9 @@
           "ch": 7
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -444,7 +444,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -463,7 +463,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -482,7 +482,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -501,7 +501,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -520,7 +520,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -539,7 +539,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -558,7 +558,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_simple.py.golden
@@ -14,9 +14,9 @@
           "ch": 21
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -229,9 +229,9 @@
           "ch": 13
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -246,7 +246,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -261,7 +261,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -276,7 +276,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -291,7 +291,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -306,7 +306,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -321,7 +321,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -336,7 +336,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_with_groupers_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_groupers_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 38
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -34,7 +34,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -310,9 +310,9 @@
           "ch": 45
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -333,7 +333,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -354,7 +354,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -375,7 +375,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -396,7 +396,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -417,7 +417,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -438,7 +438,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -459,7 +459,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -480,7 +480,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_with_level_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_level_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 52
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -266,9 +266,9 @@
           "ch": 59
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -286,7 +286,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -304,7 +304,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -322,7 +322,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -340,7 +340,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -358,7 +358,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -376,7 +376,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -394,7 +394,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -412,7 +412,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/groupby_with_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 18
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -228,9 +228,9 @@
           "ch": 25
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -245,7 +245,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -260,7 +260,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -275,7 +275,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -290,7 +290,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -305,7 +305,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -320,7 +320,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -335,7 +335,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -350,7 +350,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/head_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 12
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/head_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/head_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 9
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/e2e_golden/homepage_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/homepage_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 30
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -145,7 +145,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -160,7 +160,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -175,7 +175,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -190,7 +190,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -205,7 +205,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -220,7 +220,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -235,7 +235,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -250,7 +250,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -265,7 +265,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -777,9 +777,9 @@
           "ch": 22
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -788,7 +788,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -803,7 +803,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -818,7 +818,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -833,7 +833,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -848,7 +848,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -863,7 +863,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -878,7 +878,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -893,7 +893,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -908,7 +908,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -923,7 +923,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -938,7 +938,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -953,7 +953,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -968,7 +968,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -983,7 +983,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -998,7 +998,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1013,7 +1013,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1028,7 +1028,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",
@@ -1197,9 +1197,9 @@
           "ch": 18
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -1208,7 +1208,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrameGroupBy",
@@ -1442,9 +1442,9 @@
           "ch": 27
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1459,7 +1459,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1474,7 +1474,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1489,7 +1489,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1504,7 +1504,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1519,7 +1519,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1534,7 +1534,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1549,7 +1549,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1564,7 +1564,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1579,7 +1579,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1594,7 +1594,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1609,7 +1609,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1624,7 +1624,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1639,7 +1639,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1654,7 +1654,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1669,7 +1669,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -1684,7 +1684,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_col.py.golden
@@ -14,9 +14,9 @@
           "ch": 16
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_into_series_row.py.golden
@@ -14,8 +14,8 @@
           "ch": 23
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -183,9 +183,9 @@
           "ch": 31
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -199,7 +199,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 17
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -91,7 +91,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -106,7 +106,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/iloc_slice_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 12
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 14
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_into_series_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 25
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_nested.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_nested.py.golden
@@ -14,9 +14,9 @@
           "ch": 48
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -91,7 +91,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -106,7 +106,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_of_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_of_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 17
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 30
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -91,7 +91,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -106,7 +106,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -121,7 +121,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_slice_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 28
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 24
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -306,9 +306,9 @@
           "ch": 34
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -323,7 +323,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -338,7 +338,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -353,7 +353,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -368,7 +368,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -383,7 +383,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -398,7 +398,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/loc_vs_iloc_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 24
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -306,9 +306,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -323,7 +323,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -338,7 +338,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -353,7 +353,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -368,7 +368,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/memory_cap_ok.py.golden
+++ b/pandas_tutor/tests/e2e_golden/memory_cap_ok.py.golden
@@ -14,9 +14,9 @@
           "ch": 10
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -91,7 +91,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/na_vals_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 22
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_cols.py.golden
@@ -14,9 +14,9 @@
           "ch": 56
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -33,7 +33,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -50,7 +50,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_fn.py.golden
@@ -14,8 +14,8 @@
           "ch": 28
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_rows.py.golden
@@ -14,9 +14,9 @@
           "ch": 43
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -33,7 +33,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -50,7 +50,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/rename_series_dict.py.golden
+++ b/pandas_tutor/tests/e2e_golden/rename_series_dict.py.golden
@@ -14,9 +14,9 @@
           "ch": 34
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -33,7 +33,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "label",
             "anchor": "lhs",
@@ -50,7 +50,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_basic.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_basic.py.golden
@@ -14,9 +14,9 @@
           "ch": 18
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_drop.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_drop.py.golden
@@ -14,9 +14,9 @@
           "ch": 35
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "crossout",
+          "type": "drop",
           "pos": {
             "type": "index_level",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_level_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_level_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 24
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_level_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_level_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 29
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_multi.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_multi.py.golden
@@ -14,9 +14,9 @@
           "ch": 17
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/reset_index_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/reset_index_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 12
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -144,9 +144,9 @@
           "ch": 26
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "index_level",
             "anchor": "lhs",
@@ -161,7 +161,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/scalar_output_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 17
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -152,8 +152,8 @@
           "ch": 24
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Unhandled",

--- a/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/series_as_intermediate_val_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 13
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -152,8 +152,8 @@
           "ch": 24
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/slice_double.py.golden
+++ b/pandas_tutor/tests/e2e_golden/slice_double.py.golden
@@ -14,9 +14,9 @@
           "ch": 16
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -30,7 +30,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -312,9 +312,9 @@
           "ch": 22
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -329,7 +329,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -344,7 +344,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -359,7 +359,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -374,7 +374,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -389,7 +389,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "Series",

--- a/pandas_tutor/tests/e2e_golden/sort_series.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_series.py.golden
@@ -14,9 +14,9 @@
           "ch": 15
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -61,7 +61,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -76,7 +76,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_basic.py.golden
@@ -14,9 +14,9 @@
           "ch": 22
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -145,7 +145,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -160,7 +160,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_kwarg.py.golden
@@ -14,9 +14,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -145,7 +145,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -160,7 +160,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
+++ b/pandas_tutor/tests/e2e_golden/sort_values_twice.py.golden
@@ -14,9 +14,9 @@
           "ch": 22
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -25,7 +25,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -40,7 +40,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -55,7 +55,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -70,7 +70,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -85,7 +85,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -100,7 +100,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -115,7 +115,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -130,7 +130,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -145,7 +145,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -160,7 +160,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -377,9 +377,9 @@
           "ch": 43
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "rhs",
@@ -388,7 +388,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -403,7 +403,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -418,7 +418,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -433,7 +433,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -448,7 +448,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -463,7 +463,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -478,7 +478,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -493,7 +493,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -508,7 +508,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -523,7 +523,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -538,7 +538,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/e2e_golden/tail_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 12
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/e2e_golden/tail_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/tail_series_01.py.golden
@@ -14,9 +14,9 @@
           "ch": 9
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -31,7 +31,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -46,7 +46,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_01.py.golden
@@ -14,8 +14,8 @@
           "ch": 18
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": {
           "type": "Series",
           "index": {

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_02.py.golden
@@ -14,9 +14,9 @@
           "ch": 27
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {

--- a/pandas_tutor/tests/pg_wreck_it/crash_groupby_with_na.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/crash_groupby_with_na.py.golden
@@ -14,9 +14,9 @@
           "ch": 33
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "highlight",
+          "type": "using",
           "pos": {
             "type": "axis",
             "anchor": "lhs",
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": {
           "type": "DataFrame",
           "columns": {
@@ -178,9 +178,9 @@
           "ch": 39
         }
       },
-      "mapping": [
+      "marks": [
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -195,7 +195,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -225,7 +225,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "illustrate": "outline",
+          "type": "map",
           "from": {
             "type": "axis",
             "anchor": "lhs",
@@ -255,7 +255,7 @@
           }
         }
       ],
-      "data_frame": {
+      "data": {
         "lhs": "prev_rhs",
         "rhs": {
           "type": "DataFrame",

--- a/pandas_tutor/tests/pg_wreck_it/stdout_01.py.golden
+++ b/pandas_tutor/tests/pg_wreck_it/stdout_01.py.golden
@@ -14,8 +14,8 @@
           "ch": 5
         }
       },
-      "mapping": [],
-      "data_frame": {
+      "marks": [],
+      "data": {
         "lhs": {
           "type": "Unhandled",
           "data": "<built-in function print>"


### PR DESCRIPTION
renamed the marks to describe the data operation rather than what kind of thing to draw visually.

list of changes:

- in Diagram: `mapping` -> `marks`
- in Diagram: `data_frame` -> `data`
- in Mark: `illustrate` -> `type` (to be consistent with the other JSON objects that use `type` to distinguish between, well, different types of output.)
- `Highlight` mark -> `Using` mark, to represent the data we're using for an operation (e.g. sort **using** the `year` column).
- `Outline` mark -> `Map` mark, to represent data we're mapping from LHS to RHS
- `CrossOut` mark -> `Drop` mark, to represent data we're dropping.