### PR TITLE
stack()

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,10 @@
       "label": "tests",
       "type": "shell",
       "command": "make typecheck test",
+      "presentation": {
+        "reveal": "never",
+        "clear": true
+      },
       "problemMatcher": [],
       "group": {
         "kind": "build",

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -32,6 +32,7 @@ from .parse_nodes import (
     RenameCall,
     ResetIndexCall,
     SortValuesCall,
+    StackCall,
     SubsComparison,
     Subscript,
     SubscriptEl,
@@ -81,6 +82,8 @@ def make_marks(
         return mark_for_reset_index(step, before, after)
     elif isinstance(step, UnstackCall):
         return mark_for_unstack(step, before, after)
+    elif isinstance(step, StackCall):
+        return mark_for_stack(step, before, after)
     elif isinstance(step, Subscript):
         return mark_for_subscript(step, before, after)
     else:
@@ -299,6 +302,10 @@ def mark_for_unstack(
     df = before.val
     args = after.args
 
+    # normally, pandas unstacks the index into the columns. but when there's
+    # only one index level, pandas instead returns a series with the unstacked
+    # index levels. it's a pretty strange edge case to draw arrows for, so we
+    # don't handle it.
     if not util.is_multi(df.index):
         return []
 
@@ -312,6 +319,34 @@ def mark_for_unstack(
         Map(
             IndexLevelPos("lhs", "row", level),
             IndexLevelPos("rhs", "column", index_level + n_column_levels),
+        )
+        for index_level, level in enumerate(levels)
+    ]
+
+
+# counts.stack(level=-1, drop_na=False)
+def mark_for_stack(
+    step: StackCall, before: EvalResult, after: EvalResult
+) -> t.List[Mark]:
+    if not (
+        isinstance(before, (DFResult))
+        and isinstance(after, (DFResult, SeriesResult))
+    ):
+        return []
+
+    df = before.val
+    args = after.args
+
+    levels = util.listify(args.get("level", len(df.columns.names) - 1))
+    levels = [util.level_as_int(df.columns, level) for level in levels]
+
+    # stacking puts the new levels **after** the existing ones
+    n_index_levels = len(df.index.names)
+
+    return [
+        Map(
+            IndexLevelPos("lhs", "column", level),
+            IndexLevelPos("rhs", "row", index_level + n_index_levels),
         )
         for index_level, level in enumerate(levels)
     ]

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -41,6 +41,7 @@ from .parse_nodes import (
     RenameCall,
     ResetIndexCall,
     SortValuesCall,
+    StackCall,
     StartOfChain,
     SubsComparison,
     Subscript,
@@ -127,6 +128,7 @@ is_apply = fn_matcher("apply")
 is_assign = fn_matcher("assign")
 is_reset_index = fn_matcher("reset_index")
 is_unstack = fn_matcher("unstack")
+is_stack = fn_matcher("stack")
 
 # make sure to update this whenever we add a new call to the section above
 is_parsed_call = (
@@ -139,6 +141,7 @@ is_parsed_call = (
     | is_assign
     | is_reset_index
     | is_unstack
+    | is_stack
 )
 
 is_loc_iloc = m.Subscript(
@@ -464,6 +467,17 @@ class ChainParser(ParserBase):
 
         node = self.make_call_node(
             UnstackCall,
+            cst_node,
+            level_expr=level_expr,
+        )
+        self._append(node)
+
+    @m.leave(is_stack)
+    def make_stack(self, cst_node):
+        level_expr = self.get_arg_code(cst_node.args, 0, "level")
+
+        node = self.make_call_node(
+            StackCall,
             cst_node,
             level_expr=level_expr,
         )

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -150,7 +150,7 @@ is_boolean_slice = m.Comparison() | m.BinaryOperation(
 )
 
 
-def get_arg_by_position_or_keyword(
+def get_arg(
     args: t.Sequence[cst.Arg], position: int, keyword: t.Optional[str] = None
 ) -> t.Optional[cst.Arg]:
     """
@@ -356,17 +356,9 @@ class ChainParser(ParserBase):
 
     @m.leave(is_sort_values)
     def make_sort_values_call(self, cst_node):
-        by = get_arg_by_position_or_keyword(cst_node.args, 0, "by")
-        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, "axis")
-
-        label_expr = self.code_for(by.value) if by is not None else ""
-
-        # default sort_values uses rows
-        axis = (
-            make_axis(self.code_for(axis_arg.value))
-            if axis_arg is not None
-            else "index"
-        )
+        label_expr = self.get_arg_code(cst_node.args, 0, "by")
+        axis_arg = self.get_arg_code(cst_node.args, 1, "axis")
+        axis = make_axis(axis_arg) if axis_arg is not None else "index"
 
         node = self.make_call_node(
             SortValuesCall, cst_node, label_expr=label_expr, axis=axis
@@ -375,33 +367,17 @@ class ChainParser(ParserBase):
 
     @m.leave(is_drop)
     def make_drop_call(self, cst_node):
-        labels = get_arg_by_position_or_keyword(cst_node.args, 0, "labels")
-        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, "axis")
-        row_expr = get_arg_by_position_or_keyword(cst_node.args, 2, "index")
-        col_expr = get_arg_by_position_or_keyword(cst_node.args, 3, "columns")
-        axis = "index"  # default
-
-        if row_expr is not None:
-            row_expr = (
-                self.code_for(row_expr.value) if row_expr is not None else ""
-            )
-        if col_expr is not None:
-            col_expr = (
-                self.code_for(col_expr.value) if col_expr is not None else ""
-            )
-
-        if axis_arg is not None:
-            axis = make_axis(self.code_for(axis_arg.value))
+        labels = self.get_arg_code(cst_node.args, 0, "labels")
+        axis_arg = self.get_arg_code(cst_node.args, 1, "axis")
+        row_expr = self.get_arg_code(cst_node.args, 2, "index")
+        col_expr = self.get_arg_code(cst_node.args, 3, "columns")
+        axis = make_axis(axis_arg) if axis_arg is not None else "index"
 
         if labels is not None:
             if axis == "columns":
-                col_expr = (
-                    self.code_for(labels.value) if labels is not None else ""
-                )
+                col_expr = labels
             else:
-                row_expr = (
-                    self.code_for(labels.value) if labels is not None else ""
-                )
+                row_expr = labels
 
         node = self.make_call_node(
             DropCall, cst_node, col_expr=col_expr, row_expr=row_expr
@@ -410,10 +386,10 @@ class ChainParser(ParserBase):
 
     @m.leave(is_rename)
     def make_rename_call(self, cst_node):
-        mapper = get_arg_by_position_or_keyword(cst_node.args, 0, "mapper")
-        index = get_arg_by_position_or_keyword(cst_node.args, 1, "index")
-        columns = get_arg_by_position_or_keyword(cst_node.args, 2, "columns")
-        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 3, "axis")
+        mapper = get_arg(cst_node.args, 0, "mapper")
+        index = get_arg(cst_node.args, 1, "index")
+        columns = get_arg(cst_node.args, 2, "columns")
+        axis_arg = get_arg(cst_node.args, 3, "axis")
         axis = "index"  # default
 
         if index is not None:
@@ -441,10 +417,9 @@ class ChainParser(ParserBase):
     def make_apply(self, cst_node):
         # axis only available for dataframes...for series, arg 1 is some other
         # arg that we don't care about so we should be careful here
-        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, "axis")
-        axis = "index"  # default
-        if axis_arg is not None:
-            axis = make_axis(self.code_for(axis_arg.value))
+        axis_arg = self.get_arg_code(cst_node.args, 1, "axis")
+        axis = make_axis(axis_arg) if axis_arg is not None else "index"
+
         node = self.make_call_node(ApplyCall, cst_node, axis=axis)
         self._append(node)
 
@@ -464,28 +439,16 @@ class ChainParser(ParserBase):
 
     @m.leave(is_groupby)
     def make_groupby(self, cst_node):
-        axis_arg = get_arg_by_position_or_keyword(cst_node.args, 1, "axis")
-
-        # default groupby uses rows
-        axis = (
-            make_axis(self.code_for(axis_arg.value))
-            if axis_arg is not None
-            else "index"
-        )
+        axis_arg = self.get_arg_code(cst_node.args, 1, "axis")
+        axis = make_axis(axis_arg) if axis_arg is not None else "index"
 
         node = self.make_call_node(GroupByCall, cst_node, axis=axis)
         self._append(node)
 
     @m.leave(is_reset_index)
     def make_reset_index(self, cst_node):
-        level_expr = get_arg_by_position_or_keyword(cst_node.args, 0, "level")
-        drop_expr = get_arg_by_position_or_keyword(
-            cst_node.args, 1, "drop")
-
-        if level_expr is not None:
-            level_expr = self.code_for(level_expr.value)
-        if drop_expr is not None:
-            drop_expr = self.code_for(drop_expr.value)
+        level_expr = self.get_arg_code(cst_node.args, 0, "level")
+        drop_expr = self.get_arg_code(cst_node.args, 1, "drop")
 
         node = self.make_call_node(
             ResetIndexCall,
@@ -497,21 +460,12 @@ class ChainParser(ParserBase):
 
     @m.leave(is_unstack)
     def make_unstack(self, cst_node):
-        level_expr = get_arg_by_position_or_keyword(cst_node.args, 0, "level")
-        fill_value_expr = get_arg_by_position_or_keyword(
-            cst_node.args, 1, "fill_value"
-        )
-
-        if level_expr is not None:
-            level_expr = self.code_for(level_expr.value)
-        if fill_value_expr is not None:
-            fill_value_expr = self.code_for(fill_value_expr.value)
+        level_expr = self.get_arg_code(cst_node.args, 0, "level")
 
         node = self.make_call_node(
             UnstackCall,
             cst_node,
             level_expr=level_expr,
-            fill_value_expr=fill_value_expr,
         )
         self._append(node)
 
@@ -526,6 +480,15 @@ class ChainParser(ParserBase):
         location = CodeRange(dot.start, entire_expr.end)
 
         return self.make_node(cls, cst_node, location=location, **kwargs)
+
+    def get_arg_code(
+        self,
+        args: t.Sequence[cst.Arg],
+        position: int,
+        keyword: t.Optional[str] = None,
+    ) -> t.Optional[RawCode]:
+        arg = get_arg(args, position, keyword)
+        return arg if arg is None else self.code_for(arg.value)
 
 
 class SubscriptParser(ParserBase):

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -273,7 +273,20 @@ class UnstackCall(Call):
     fn_name = "unstack"
 
     level_expr: t.Optional[RawCode] = evals_into("level")
-    fill_value_expr: t.Optional[RawCode] = evals_into("fill_value")
+
+
+@dataclasses.dataclass
+class StackCall(Call):
+    """
+    counts.stack()
+    counts.stack(level=1)
+    counts.stack(level=[1, 2])
+    counts.stack(level=-1, dropna=True)
+    """
+
+    fn_name = "stack"
+
+    level_expr: t.Optional[RawCode] = evals_into("level")
 
 
 ##############################################################################

--- a/pandas_tutor/tests/e2e_golden/stack_basic_01.py
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_01.py
@@ -1,0 +1,8 @@
+# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html
+import pandas as pd
+
+df_single_level_cols = pd.DataFrame(
+    [[0, 1], [2, 3]], index=["cat", "dog"], columns=["weight", "height"]
+)
+
+df_single_level_cols.stack()

--- a/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
@@ -1,0 +1,102 @@
+{
+  "code": "# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html\nimport pandas as pd\n\ndf_single_level_cols = pd.DataFrame(\n    [[0, 1], [2, 3]], index=[\"cat\", \"dog\"], columns=[\"weight\", \"height\"]\n)\n\ndf_single_level_cols.stack()\n",
+  "explanation": [
+    {
+      "type": "StackCall",
+      "code_step": "df_single_level_cols.stack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 20
+        },
+        "end": {
+          "line": 0,
+          "ch": 28
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "weight",
+              "height"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "cat",
+              "dog"
+            ]
+          },
+          "data": [
+            [
+              0,
+              1
+            ],
+            [
+              2,
+              3
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "Series",
+          "index": {
+            "names": [
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "cat",
+                "weight"
+              ],
+              [
+                "cat",
+                "height"
+              ],
+              [
+                "dog",
+                "weight"
+              ],
+              [
+                "dog",
+                "height"
+              ]
+            ]
+          },
+          "data": [
+            0,
+            1,
+            2,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/stack_basic_02.py
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_02.py
@@ -1,0 +1,8 @@
+# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html
+import pandas as pd
+multicol1 = pd.MultiIndex.from_tuples([('weight', 'kg'),
+                                       ('weight', 'pounds')])
+df_multi_level_cols1 = pd.DataFrame([[1, 2], [2, 4]],
+                                    index=['cat', 'dog'],
+                                    columns=multicol1)
+df_multi_level_cols1.stack()

--- a/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
@@ -1,0 +1,125 @@
+{
+  "code": "# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html\nimport pandas as pd\nmulticol1 = pd.MultiIndex.from_tuples([('weight', 'kg'),\n                                       ('weight', 'pounds')])\ndf_multi_level_cols1 = pd.DataFrame([[1, 2], [2, 4]],\n                                    index=['cat', 'dog'],\n                                    columns=multicol1)\ndf_multi_level_cols1.stack()",
+  "explanation": [
+    {
+      "type": "StackCall",
+      "code_step": "df_multi_level_cols1.stack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 20
+        },
+        "end": {
+          "line": 0,
+          "ch": 28
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "weight",
+                "kg"
+              ],
+              [
+                "weight",
+                "pounds"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "cat",
+              "dog"
+            ]
+          },
+          "data": [
+            [
+              1,
+              2
+            ],
+            [
+              2,
+              4
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "weight"
+            ]
+          },
+          "index": {
+            "names": [
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "cat",
+                "kg"
+              ],
+              [
+                "cat",
+                "pounds"
+              ],
+              [
+                "dog",
+                "kg"
+              ],
+              [
+                "dog",
+                "pounds"
+              ]
+            ]
+          },
+          "data": [
+            [
+              1
+            ],
+            [
+              2
+            ],
+            [
+              2
+            ],
+            [
+              4
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py
@@ -1,0 +1,20 @@
+# https://github.com/SamLau95/pandas_tutor/issues/86
+# adapted from Thinking in Pandas
+import pandas as pd
+
+restaurants = pd.MultiIndex.from_tuples(
+    (("Diner", (4, 2)), ("Pandas", (5, 4))),
+    names=["restaurant", "location"],
+)
+inspections = pd.MultiIndex.from_tuples(
+    ((0, "score"), (0, "date"), (1, "score"), (1, "date")),
+    names=["inspection", None],
+)
+
+restaurant_inspections = pd.DataFrame(
+    [[90, "02/18", 100, "05/18"], [55, "04/18", 76, "01/18"]],
+    index=restaurants,
+    columns=inspections,
+)
+
+restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
@@ -1,0 +1,837 @@
+{
+  "code": "# https://github.com/SamLau95/pandas_tutor/issues/86\n# adapted from Thinking in Pandas\nimport pandas as pd\n\nrestaurants = pd.MultiIndex.from_tuples(\n    ((\"Diner\", (4, 2)), (\"Pandas\", (5, 4))),\n    names=[\"restaurant\", \"location\"],\n)\ninspections = pd.MultiIndex.from_tuples(\n    ((0, \"score\"), (0, \"date\"), (1, \"score\"), (1, \"date\")),\n    names=[\"inspection\", None],\n)\n\nrestaurant_inspections = pd.DataFrame(\n    [[90, \"02/18\", 100, \"05/18\"], [55, \"04/18\", 76, \"01/18\"]],\n    index=restaurants,\n    columns=inspections,\n)\n\nrestaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()\n",
+  "explanation": [
+    {
+      "type": "StackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 22
+        },
+        "end": {
+          "line": 0,
+          "ch": 30
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 2
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "inspection",
+              null
+            ],
+            "labels": [
+              [
+                0,
+                "score"
+              ],
+              [
+                0,
+                "date"
+              ],
+              [
+                1,
+                "score"
+              ],
+              [
+                1,
+                "date"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              "restaurant",
+              "location"
+            ],
+            "labels": [
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ]
+              ]
+            ]
+          },
+          "data": [
+            [
+              90,
+              "02/18",
+              100,
+              "05/18"
+            ],
+            [
+              55,
+              "04/18",
+              76,
+              "01/18"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "inspection"
+            ],
+            "labels": [
+              0,
+              1
+            ]
+          },
+          "index": {
+            "names": [
+              "restaurant",
+              "location",
+              null
+            ],
+            "labels": [
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "date"
+              ],
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "score"
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "date"
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "score"
+              ]
+            ]
+          },
+          "data": [
+            [
+              "02/18",
+              "05/18"
+            ],
+            [
+              90,
+              100
+            ],
+            [
+              "04/18",
+              "01/18"
+            ],
+            [
+              55,
+              76
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "type": "StackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 30
+        },
+        "end": {
+          "line": 0,
+          "ch": 38
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 3
+          }
+        }
+      ],
+      "data": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "Series",
+          "index": {
+            "names": [
+              "restaurant",
+              "location",
+              null,
+              "inspection"
+            ],
+            "labels": [
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "date",
+                0
+              ],
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "date",
+                1
+              ],
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "score",
+                0
+              ],
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "score",
+                1
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "date",
+                0
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "date",
+                1
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "score",
+                0
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "score",
+                1
+              ]
+            ]
+          },
+          "data": [
+            "02/18",
+            "05/18",
+            90,
+            100,
+            "04/18",
+            "01/18",
+            55,
+            76
+          ]
+        }
+      }
+    },
+    {
+      "type": "UnstackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 38
+        },
+        "end": {
+          "line": 0,
+          "ch": 48
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 3
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        }
+      ],
+      "data": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "inspection"
+            ],
+            "labels": [
+              0,
+              1
+            ]
+          },
+          "index": {
+            "names": [
+              "restaurant",
+              "location",
+              null
+            ],
+            "labels": [
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "date"
+              ],
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ],
+                "score"
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "date"
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ],
+                "score"
+              ]
+            ]
+          },
+          "data": [
+            [
+              "02/18",
+              "05/18"
+            ],
+            [
+              90,
+              100
+            ],
+            [
+              "04/18",
+              "01/18"
+            ],
+            [
+              55,
+              76
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "type": "UnstackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 48
+        },
+        "end": {
+          "line": 0,
+          "ch": 58
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 2
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        }
+      ],
+      "data": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "inspection",
+              null
+            ],
+            "labels": [
+              [
+                0,
+                "date"
+              ],
+              [
+                0,
+                "score"
+              ],
+              [
+                1,
+                "date"
+              ],
+              [
+                1,
+                "score"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              "restaurant",
+              "location"
+            ],
+            "labels": [
+              [
+                "Diner",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                "Pandas",
+                [
+                  5,
+                  4
+                ]
+              ]
+            ]
+          },
+          "data": [
+            [
+              "02/18",
+              90,
+              "05/18",
+              100
+            ],
+            [
+              "04/18",
+              55,
+              "01/18",
+              76
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "type": "UnstackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 58
+        },
+        "end": {
+          "line": 0,
+          "ch": 68
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 1
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 2
+          }
+        }
+      ],
+      "data": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "inspection",
+              null,
+              "location"
+            ],
+            "labels": [
+              [
+                0,
+                "date",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                0,
+                "date",
+                [
+                  5,
+                  4
+                ]
+              ],
+              [
+                0,
+                "score",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                0,
+                "score",
+                [
+                  5,
+                  4
+                ]
+              ],
+              [
+                1,
+                "date",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                1,
+                "date",
+                [
+                  5,
+                  4
+                ]
+              ],
+              [
+                1,
+                "score",
+                [
+                  4,
+                  2
+                ]
+              ],
+              [
+                1,
+                "score",
+                [
+                  5,
+                  4
+                ]
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              "restaurant"
+            ],
+            "labels": [
+              "Diner",
+              "Pandas"
+            ]
+          },
+          "data": [
+            [
+              "02/18",
+              null,
+              90,
+              null,
+              "05/18",
+              null,
+              100,
+              null
+            ],
+            [
+              null,
+              "04/18",
+              null,
+              55,
+              null,
+              "01/18",
+              null,
+              76
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "type": "UnstackCall",
+      "code_step": "restaurant_inspections.stack().stack().unstack().unstack().unstack().unstack()",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 68
+        },
+        "end": {
+          "line": 0,
+          "ch": 78
+        }
+      },
+      "marks": [],
+      "data": {
+        "lhs": "prev_rhs",
+        "rhs": {
+          "type": "Series",
+          "index": {
+            "names": [
+              "inspection",
+              null,
+              "location",
+              "restaurant"
+            ],
+            "labels": [
+              [
+                0,
+                "date",
+                [
+                  4,
+                  2
+                ],
+                "Diner"
+              ],
+              [
+                0,
+                "date",
+                [
+                  4,
+                  2
+                ],
+                "Pandas"
+              ],
+              [
+                0,
+                "date",
+                [
+                  5,
+                  4
+                ],
+                "Diner"
+              ],
+              [
+                0,
+                "date",
+                [
+                  5,
+                  4
+                ],
+                "Pandas"
+              ],
+              [
+                0,
+                "score",
+                [
+                  4,
+                  2
+                ],
+                "Diner"
+              ],
+              [
+                0,
+                "score",
+                [
+                  4,
+                  2
+                ],
+                "Pandas"
+              ],
+              [
+                0,
+                "score",
+                [
+                  5,
+                  4
+                ],
+                "Diner"
+              ],
+              [
+                0,
+                "score",
+                [
+                  5,
+                  4
+                ],
+                "Pandas"
+              ],
+              [
+                1,
+                "date",
+                [
+                  4,
+                  2
+                ],
+                "Diner"
+              ],
+              [
+                1,
+                "date",
+                [
+                  4,
+                  2
+                ],
+                "Pandas"
+              ],
+              [
+                1,
+                "date",
+                [
+                  5,
+                  4
+                ],
+                "Diner"
+              ],
+              [
+                1,
+                "date",
+                [
+                  5,
+                  4
+                ],
+                "Pandas"
+              ],
+              [
+                1,
+                "score",
+                [
+                  4,
+                  2
+                ],
+                "Diner"
+              ],
+              [
+                1,
+                "score",
+                [
+                  4,
+                  2
+                ],
+                "Pandas"
+              ],
+              [
+                1,
+                "score",
+                [
+                  5,
+                  4
+                ],
+                "Diner"
+              ],
+              [
+                1,
+                "score",
+                [
+                  5,
+                  4
+                ],
+                "Pandas"
+              ]
+            ]
+          },
+          "data": [
+            "02/18",
+            null,
+            null,
+            "04/18",
+            90,
+            null,
+            null,
+            55,
+            "05/18",
+            null,
+            null,
+            "01/18",
+            100,
+            null,
+            null,
+            76
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/stack_multi_01.py
+++ b/pandas_tutor/tests/e2e_golden/stack_multi_01.py
@@ -1,0 +1,10 @@
+# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html
+import pandas as pd
+
+multicol2 = pd.MultiIndex.from_tuples([('weight', 'kg'),
+                                       ('height', 'm')])
+df_multi_level_cols2 = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]],
+                                    index=['cat', 'dog'],
+                                    columns=multicol2)
+
+df_multi_level_cols2.stack([0, 1])

--- a/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
@@ -1,0 +1,129 @@
+{
+  "code": "# https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html\nimport pandas as pd\n\nmulticol2 = pd.MultiIndex.from_tuples([('weight', 'kg'),\n                                       ('height', 'm')])\ndf_multi_level_cols2 = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]],\n                                    index=['cat', 'dog'],\n                                    columns=multicol2)\n\ndf_multi_level_cols2.stack([0, 1])",
+  "explanation": [
+    {
+      "type": "StackCall",
+      "code_step": "df_multi_level_cols2.stack([0, 1])",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 20
+        },
+        "end": {
+          "line": 0,
+          "ch": 34
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 2
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "weight",
+                "kg"
+              ],
+              [
+                "height",
+                "m"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "cat",
+              "dog"
+            ]
+          },
+          "data": [
+            [
+              1.0,
+              2.0
+            ],
+            [
+              3.0,
+              4.0
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "Series",
+          "index": {
+            "names": [
+              null,
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "cat",
+                "height",
+                "m"
+              ],
+              [
+                "cat",
+                "weight",
+                "kg"
+              ],
+              [
+                "dog",
+                "height",
+                "m"
+              ],
+              [
+                "dog",
+                "weight",
+                "kg"
+              ]
+            ]
+          },
+          "data": [
+            2.0,
+            1.0,
+            4.0,
+            3.0
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/86

now we can draw diagrams for `stack()` calls. we're only mapping index levels right now. doing cell-to-cell mapping is a bit trickier, so i'm leaving that for a future PR.

https://github.com/SamLau95/pandas_tutor/blob/46335374597a7ea9eafbc7d8fea856951142c202/pandas_tutor/tests/e2e_golden/stack_multi_01.py#L6-L10

https://github.com/SamLau95/pandas_tutor/blob/46335374597a7ea9eafbc7d8fea856951142c202/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden#L17-L48