### PR TITLE
reshape cell to cell mappings

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -14,7 +14,7 @@ import simplejson as json
 
 from .parse_nodes import ParseSyntaxError
 from .run import RuntimeErrorResult
-from .util import SERIES, CodePosition, CodeRange, JSONScalar, Label
+from .util import SERIES, CodePosition, CodeRange, JSONScalar, Label, unwrap
 
 
 @dataclasses.dataclass
@@ -230,6 +230,8 @@ class CellPos(TablePos):
 
     def __post_init__(self):
         self.type = "cell"
+        self.row = unwrap(self.row)
+        self.column = unwrap(self.column)
 
 
 ##############################################################################

--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -14,7 +14,7 @@ import simplejson as json
 
 from .parse_nodes import ParseSyntaxError
 from .run import RuntimeErrorResult
-from .util import CodePosition, CodeRange, JSONScalar, Label
+from .util import SERIES, CodePosition, CodeRange, JSONScalar, Label
 
 
 @dataclasses.dataclass
@@ -125,7 +125,7 @@ IndexLevel = t.Union[None, int]
 
 # each TablePos object is serialized as one of these
 TablePosType = t.Literal[
-    "axis", "series", "label", "index_level", "index_name", "datum"
+    "axis", "series", "label", "index_level", "index_name", "cell"
 ]
 
 
@@ -167,7 +167,7 @@ class SeriesPos(TablePos):
     """points to an entire series"""
 
     anchor: Anchor
-    label: Label = field(default="pandas.Series", init=False)
+    label: Label = field(default=SERIES, init=False)
 
     def __post_init__(self):
         self.type = "series"
@@ -217,15 +217,19 @@ class IndexNamePos(TablePos):
 
 
 @dataclasses.dataclass
-class DatumPos(TablePos):
-    """points to a single datum in the table"""
+class CellPos(TablePos):
+    """
+    points to a single cell in the table, which is uniquely identified by
+    the combination of column and row label.
+    """
 
     anchor: Anchor
-    column: Label
     row: Label
+    # for Series, column is util.SERIES
+    column: Label
 
     def __post_init__(self):
-        self.type = "datum"
+        self.type = "cell"
 
 
 ##############################################################################

--- a/pandas_tutor/main.py
+++ b/pandas_tutor/main.py
@@ -11,14 +11,12 @@ Options:
     -l --parse_log   # Outputs parse debug output
     -c --code        # Code as a string (instead of a file)
 """
-import typing as t
 from pathlib import Path
 
 from docopt import docopt
 
 from .diagram import OutputSpec
 from .parse import parse, parse_as_json, test_logger
-from .parse_nodes import ParseSyntaxError
 from .run import run
 from .serialize import serialize
 

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -1,7 +1,8 @@
 """
 creates mark specs. here's where the magic happens!
 """
-import typing as t
+from collections.abc import Iterable
+from typing import Any, List, Optional, Union
 
 import pandas as pd
 
@@ -9,15 +10,16 @@ from . import util
 from .diagram import (
     Anchor,
     AxisPos,
+    CellPos,
     Drop,
     IndexLevel,
-    Using,
     IndexLevelPos,
     LabelPos,
-    Mark,
     Map,
+    Mark,
     Selection,
     SeriesPos,
+    Using,
 )
 from .parse_nodes import (
     AggCall,
@@ -55,7 +57,7 @@ from .run import (
 # the type checker.
 def make_marks(
     step: ChainStep, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     """
     computes the marks for a given step by dispatching to the right marks
     function. returns empty list if we don't know how to make marks.
@@ -97,7 +99,7 @@ def make_marks(
 # df.sort_values('Name')
 def mark_for_sort_values(
     step: SortValuesCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult, SeriesResult))
         and isinstance(after, (DFResult, SeriesResult))
@@ -123,7 +125,7 @@ def mark_for_sort_values(
 # dogs.drop(columns=['type', 'price'])
 def mark_for_drop(
     step: DropCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult, SeriesResult))
         and isinstance(after, (DFResult, SeriesResult))
@@ -149,9 +151,9 @@ def mark_for_drop(
 # df.rename(index={'sam': 'smae'})
 def mark_for_rename(
     step: RenameCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     args = after.args
-    mapping: t.Any = args.get("mapping", {})
+    mapping: Any = args.get("mapping", {})
 
     if not isinstance(mapping, dict):
         return no_marks()
@@ -167,8 +169,8 @@ def mark_for_rename(
 # df.head(2)
 # df.tail()
 def mark_for_head_or_tail(
-    step: t.Union[HeadCall, TailCall], before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+    step: Union[HeadCall, TailCall], before: EvalResult, after: EvalResult
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult, SeriesResult))
         and isinstance(after, (DFResult, SeriesResult))
@@ -180,7 +182,7 @@ def mark_for_head_or_tail(
 # df['breed'].apply(len)
 def mark_for_apply(
     step: ApplyCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if isinstance(before, DFResult) and isinstance(after, DFResult):
         df = after.val
         labels = df.index if step.axis == "index" else df.columns
@@ -203,14 +205,14 @@ def mark_for_apply(
 # dogs.assign(daily=lambda df: df['food_cost'] * 30)
 def mark_for_assign(
     step: AssignCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     return make_highlights(step.new_col_labels, "column", "rhs")
 
 
 # df.groupby('hello')
 def mark_for_groupby(
     step: GroupByCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not isinstance(after, GroupbyResult):
         return []
 
@@ -225,7 +227,7 @@ def mark_for_groupby(
 # basic heuristic: assume that group keys map to row labels of result
 def mark_for_agg(
     step: AggCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not isinstance(before, (GroupbyResult, SeriesGroupbyResult)):
         return []
     if not isinstance(after, (DFResult, SeriesResult)):
@@ -233,7 +235,7 @@ def mark_for_agg(
 
     groups = util.get_groups(before.val)
 
-    row_outlines: t.List[Mark] = []
+    row_outlines: List[Mark] = []
     for group_key, lhs_labels in groups.items():
         for label in lhs_labels:
             row_outlines.append(
@@ -252,7 +254,7 @@ def mark_for_agg(
 # let's not worry about that for now
 def mark_for_reset_index(
     step: ResetIndexCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult, SeriesResult))
         and isinstance(after, DFResult)
@@ -264,21 +266,17 @@ def mark_for_reset_index(
     # if level unspecified, pandas resets all levels
     all_levels = list(range(len(df.index.names)))
     levels = util.listify(args.get("level", all_levels))
-    # convert levels to integer positions
-    levels = [
-        df.index.names.index(level) if isinstance(level, str) else level
-        for level in levels
-    ]
+    levels = [util.level_number(df.index, level) for level in levels]
 
     if args.get("drop", False):
         return [Drop(IndexLevelPos("lhs", "row", level)) for level in levels]
 
     # recreating the pandas defaults for unnamed index levels
-    names: t.List[str]
+    names: List[str]
     if util.is_multi(df.index):
         names = [
-            n if n is not None else f"level_{i}"
-            for i, n in enumerate(df.index.names)
+            name if name is not None else f"level_{position}"
+            for position, name in enumerate(df.index.names)
         ]
     else:
         default = "index" if "index" not in df else "level_0"
@@ -296,7 +294,7 @@ def mark_for_reset_index(
 # counts.unstack(level=-1, fill_value=0)
 def mark_for_unstack(
     step: UnstackCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult, SeriesResult))
         and isinstance(after, DFResult)
@@ -307,31 +305,41 @@ def mark_for_unstack(
     args = after.args
 
     # normally, pandas unstacks the index into the columns. but when there's
-    # only one index level, pandas instead returns a series with the unstacked
-    # index levels. it's a pretty strange edge case to draw arrows for, so we
-    # don't handle it.
+    # only one index level, pandas instead transposes the dataframe, then
+    # *stacks* a level. it's a pretty strange edge case to draw arrows for, so
+    # we don't handle it.
     if not util.is_multi(df.index):
         return []
 
-    levels = util.listify(args.get("level", len(df.index.names) - 1))
-    levels = [util.level_as_int(df.index, level) for level in levels]
+    levels = util.listify(args.get("level", -1))
+    levels = [util.level_number(df.index, level) for level in levels]
 
-    # unstacking puts the new levels **under** the existing ones
-    n_column_levels = len(df.columns.names) if util.is_dataframe(df) else 0
+    columns = df.columns if util.is_dataframe(df) else pd.Index([util.SERIES])
+    n_orig_levels = len(columns)
 
-    return [
+    index_marks: List[Mark] = [
         Map(
-            IndexLevelPos("lhs", "row", level),
-            IndexLevelPos("rhs", "column", index_level + n_column_levels),
+            lhs_index("row", level),
+            # unstacking puts the new levels **under** the existing ones
+            rhs_index("column", index_level + n_orig_levels),
         )
         for index_level, level in enumerate(levels)
     ]
+
+    # for each cell: the unstacked labels move to the column index
+    cells = util.push_levels(df.index, columns, levels)
+    cell_marks: List[Mark] = [
+        Map(CellPos("lhs", old_row, old_col), CellPos("rhs", new_row, new_col))
+        for (old_row, old_col), (new_row, new_col) in cells
+    ]
+
+    return [*index_marks, *cell_marks]
 
 
 # counts.stack(level=-1, drop_na=False)
 def mark_for_stack(
     step: StackCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (
         isinstance(before, (DFResult))
         and isinstance(after, (DFResult, SeriesResult))
@@ -342,12 +350,12 @@ def mark_for_stack(
     args = after.args
 
     levels = util.listify(args.get("level", len(df.columns.names) - 1))
-    levels = [util.level_as_int(df.columns, level) for level in levels]
+    levels = [util.level_number(df.columns, level) for level in levels]
 
     # stacking puts the new levels **after** the existing ones
     n_index_levels = len(df.index.names)
 
-    return [
+    index_marks: List[Mark] = [
         Map(
             IndexLevelPos("lhs", "column", level),
             IndexLevelPos("rhs", "row", index_level + n_index_levels),
@@ -355,11 +363,24 @@ def mark_for_stack(
         for index_level, level in enumerate(levels)
     ]
 
+    # for each cell: the unstacked labels move to the row index
+    is_series = isinstance(after, SeriesResult)
+    cells = util.push_levels(df.columns, df.index, levels)
+    cell_marks: List[Mark] = [
+        Map(
+            CellPos("lhs", old_row, old_col),
+            CellPos("rhs", new_row, new_col if not is_series else util.SERIES),
+        )
+        for (old_col, old_row), (new_col, new_row) in cells
+    ]
+
+    return [*index_marks, *cell_marks]
+
 
 # df.pivot(index='foo', columns='bar', values='baz')
 def mark_for_pivot(
     step: PivotCall, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if not (isinstance(before, DFResult) and isinstance(after, DFResult)):
         return []
 
@@ -377,8 +398,8 @@ def mark_for_pivot(
     # pivoting puts the new column levels **after** the existing ones
     n_existing_col_levels = len(df.columns.names)
 
-    marks: t.List[Mark] = []
-    # each index arg becomes a level of the new index
+    marks: List[Mark] = []
+    # each index arg goes into a new index level
     for position, name in enumerate(index):
         marks.append(Map(lhs("column", name), rhs_index("row", position)))
 
@@ -402,7 +423,7 @@ def mark_for_pivot(
 # df.groupby('Sex')[['Count']]
 def mark_for_subscript(
     step: Subscript, before: EvalResult, after: EvalResult
-) -> t.List[Mark]:
+) -> List[Mark]:
     if isinstance(before, (DFResult, GroupbyResult)) and isinstance(
         after, (SeriesResult, SeriesGroupbyResult)
     ):
@@ -419,9 +440,9 @@ def mark_for_subscript(
 
 def mark_for_subscript_df_to_df(
     step: Subscript,
-    before: t.Union[DFResult, GroupbyResult],
-    after: t.Union[DFResult, GroupbyResult],
-) -> t.List[Mark]:
+    before: Union[DFResult, GroupbyResult],
+    after: Union[DFResult, GroupbyResult],
+) -> List[Mark]:
     row_slice = step.slice1
     col_slice = step.slice2
     args = after.args
@@ -453,10 +474,10 @@ def mark_for_subscript_df_to_df(
 
 
 def make_subscript_comparison_marks(
-    subs_el: t.Optional[SubscriptEl],
+    subs_el: Optional[SubscriptEl],
     labels: Arg,
     selection: Selection,
-) -> t.List[Mark]:
+) -> List[Mark]:
     """
     makes highlights for cols/rows used for filtering, if the subscript is a
     filter.
@@ -472,7 +493,7 @@ def mark_for_subscript_of_series(
     step: Subscript,
     before: SeriesResult,
     after: SeriesResult,
-) -> t.List[Mark]:
+) -> List[Mark]:
     # no special cases for comparisons since there isn't a "column" we're using
     # to filter
     return diff_rows(before.val, after.val)
@@ -480,9 +501,9 @@ def mark_for_subscript_of_series(
 
 def mark_for_subscript_into_series(
     step: Subscript,
-    before: t.Union[DFResult, GroupbyResult],
-    after: t.Union[SeriesResult, SeriesGroupbyResult],
-) -> t.List[Mark]:
+    before: Union[DFResult, GroupbyResult],
+    after: Union[SeriesResult, SeriesGroupbyResult],
+) -> List[Mark]:
     args = after.args
     before_df = util.ungroup(before.val)
     after_df = util.ungroup(after.val)
@@ -579,7 +600,7 @@ def diff_cols(df1: pd.DataFrame, df2: pd.DataFrame, only_if_diff=True):
     return make_outlines(col_matches, "column")
 
 
-def no_marks(*args) -> t.List[Mark]:
+def no_marks(*args) -> List[Mark]:
     # print(f'Unknown mark for {step.type_}')
     return []
 
@@ -591,15 +612,15 @@ def selection(axis: Axis, other=False) -> Selection:
 
 
 def make_highlights(
-    labels: t.Iterable, select: Selection, anchor: Anchor = "lhs"
-) -> t.List[Mark]:
+    labels: Iterable, select: Selection, anchor: Anchor = "lhs"
+) -> List[Mark]:
     """
     shorthand to make a highlight for each column/row in labels
     """
     return [Using(AxisPos(anchor, select, label)) for label in labels]
 
 
-def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
+def make_outlines(labels: Iterable, select: Selection) -> List[Mark]:
     """
     shorthand when index values don't change, which is most of the time
     """
@@ -608,7 +629,7 @@ def make_outlines(labels: t.Iterable, select: Selection) -> t.List[Mark]:
     ]
 
 
-def make_crossouts(labels: t.Iterable, select: Selection) -> t.List[Mark]:
+def make_crossouts(labels: Iterable, select: Selection) -> List[Mark]:
     """
     shorthand for crossouts
     """

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -2,7 +2,8 @@
 creates mark specs. here's where the magic happens!
 """
 from collections.abc import Iterable
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Tuple, Union, cast
+from collections.abc import Sequence
 
 import pandas as pd
 
@@ -381,38 +382,66 @@ def mark_for_stack(
 def mark_for_pivot(
     step: PivotCall, before: EvalResult, after: EvalResult
 ) -> List[Mark]:
+    # if index=[], pandas does the weird transpose + stack thing into a series
+    # which we won't try to handle
     if not (isinstance(before, DFResult) and isinstance(after, DFResult)):
         return []
 
     df = before.val
     args = after.args
 
-    index = util.listify(args.get("index", []))
-    columns = util.listify(args.get("columns", []))
-    values = util.listify(args.get("values", []))
+    has_index = "index" in args
+    has_values = "values" in args
+    index: List[util.Label] = util.listify(args.get("index", []))
+    columns: List[util.Label] = util.listify(args.get("columns", []))
+    # default values arg is all leftover columns
+    values: List[util.Label] = util.listify(
+        args.get("values", df.columns.drop([*index, *columns]))
+    )
+    no_value_cols = len(values) == 0
 
     # special case: when only one values column is specified, pandas
-    # doesn't keep it as a column
-    will_compress_cols = len(values) == 1
+    # doesn't keep it as a column. we need has_values since pandas only drops
+    # when values is explicitly passed in.
+    will_drop_values = has_values and len(values) == 1
+    n_orig_col_levels = len(df.columns.names) if not will_drop_values else 0
 
-    # pivoting puts the new column levels **after** the existing ones
-    n_existing_col_levels = len(df.columns.names)
-
-    marks: List[Mark] = []
     # each index arg goes into a new index level
-    for position, name in enumerate(index):
-        marks.append(Map(lhs("column", name), rhs_index("row", position)))
+    index_marks = [
+        Map(lhs("column", name), rhs_index("row", position))
+        for position, name in enumerate(index)
+    ]
+
+    # special case: result is empty dataframe with new index
+    if no_value_cols:
+        return [*index_marks]
 
     # each column arg is appended as an index level into the columns
-    for position, name in enumerate(columns):
-        new_pos = (
-            position + n_existing_col_levels
-            if not will_compress_cols
-            else position
+    column_marks = [
+        Map(
+            lhs("column", name),
+            rhs_index("column", position + n_orig_col_levels),
         )
-        marks.append(Map(lhs("column", name), rhs_index("column", new_pos)))
+        for position, name in enumerate(columns)
+    ]
 
-    return marks
+    # to make cell marks, we need to pull row and column labels from the data
+    # rows themselves so the logic is tricky
+    cell_marks = []
+    for old_row, row in df.iterrows():
+        old_row = cast(util.Label, old_row)
+        # pull new row labels from row data
+        new_row = cast(util.Label, tuple(row[index]) if has_index else old_row)
+
+        # pull new col labels from row data
+        appended = tuple(row[columns])
+        for old_col in values:
+            new_col = (old_col, *appended) if not has_values else appended
+            left = CellPos("lhs", old_row, old_col)
+            right = CellPos("rhs", new_row, new_col)
+            cell_marks.append(Map(left, right))
+
+    return [*index_marks, *column_marks, *cell_marks]
 
 
 # handler for all subscripts, like:

--- a/pandas_tutor/sams_scratchpad.py
+++ b/pandas_tutor/sams_scratchpad.py
@@ -9,7 +9,7 @@ from prettyprinter.prettyprinter import IMPLICIT_MODULES  # type: ignore
 
 from .parse import parse, test_logger, test_parser
 from .run import run
-from .main import make_tutor_spec_py
+from .main import make_tutor_spec, make_tutor_spec_py
 
 prettyprinter.install_extras(include=["dataclasses", "python", "numpy"])
 
@@ -19,7 +19,7 @@ IMPLICIT_MODULES.add("pandas_tutor.util")
 
 shorten_df = True
 
-file_to_read = "parse_golden/nested_exprs"
+file_to_read = "e2e_golden/pivot_empty_01"
 
 
 def p(obj):
@@ -30,8 +30,8 @@ if __name__ == "__main__":
     from pathlib import Path
 
     code = (Path(__file__).parent / f"tests/{file_to_read}.py").read_text()
-    root = test_parser(code)
-    test_logger(code)
+    # root = test_parser(code)
+    # test_logger(code)
     #     print(code)
     #     print('\n--------------\n')
 
@@ -42,7 +42,9 @@ if __name__ == "__main__":
     #         lhs['data'] = len(lhs['data'])
     #         rhs['data'] = len(rhs['data'])
 
-    p(root)
+    # p(root)
     # p(run(root))
+    spec = make_tutor_spec(code)
+    p(spec)
 
     print("\n---------------------------------------------------------\n")

--- a/pandas_tutor/tests/e2e_golden/pivot_columns_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_columns_01.py.golden
@@ -44,6 +44,234 @@
             "select": "column",
             "level": 2
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 0,
+            "column": [
+              "baz",
+              "one",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 0,
+            "column": [
+              "zoo",
+              "one",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 1,
+            "column": [
+              "baz",
+              "one",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 1,
+            "column": [
+              "zoo",
+              "one",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2,
+            "column": [
+              "baz",
+              "one",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2,
+            "column": [
+              "zoo",
+              "one",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 3,
+            "column": [
+              "baz",
+              "two",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 3,
+            "column": [
+              "zoo",
+              "two",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 4,
+            "column": [
+              "baz",
+              "two",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 4,
+            "column": [
+              "zoo",
+              "two",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 5,
+            "column": [
+              "baz",
+              "two",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 5,
+            "column": [
+              "zoo",
+              "two",
+              "C"
+            ]
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_01.py
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_01.py
@@ -1,0 +1,18 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+foo,bar,baz,zoo
+one,A,1,x
+one,B,2,y
+one,C,3,z
+two,A,4,q
+two,B,5,w
+two,C,6,t
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# produces an empty dataframe with two row labels
+df.pivot(index=['foo'], columns=["bar", 'baz', 'zoo'])

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_01.py
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_01.py
@@ -1,6 +1,11 @@
 # https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
-import pandas as pd
 import io
+import warnings
+
+import pandas as pd
+
+# getting a weird warning that only shows up in unittest, so let's silence it
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 csv = """
 foo,bar,baz,zoo
@@ -15,4 +20,4 @@ two,C,6,t
 df = pd.read_csv(io.StringIO(csv))
 
 # produces an empty dataframe with two row labels
-df.pivot(index=['foo'], columns=["bar", 'baz', 'zoo'])
+df.pivot(index=["foo"], columns=["bar", "baz", "zoo"])

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
@@ -1,9 +1,9 @@
 {
-  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# produces an empty dataframe with two row labels\ndf.pivot(index=['foo'], columns=[\"bar\", 'baz', 'zoo'])\n",
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport io\nimport warnings\n\nimport pandas as pd\n\n# getting a weird warning that only shows up in unittest, so let's silence it\nwarnings.filterwarnings(\"ignore\", category=DeprecationWarning)\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# produces an empty dataframe with two row labels\ndf.pivot(index=[\"foo\"], columns=[\"bar\", \"baz\", \"zoo\"])\n",
   "explanation": [
     {
       "type": "PivotCall",
-      "code_step": "df.pivot(index=['foo'], columns=[\"bar\", 'baz', 'zoo'])",
+      "code_step": "df.pivot(index=[\"foo\"], columns=[\"bar\", \"baz\", \"zoo\"])",
       "fragment": {
         "start": {
           "line": 0,

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
@@ -1,0 +1,128 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# produces an empty dataframe with two row labels\ndf.pivot(index=['foo'], columns=[\"bar\", 'baz', 'zoo'])\n",
+  "explanation": [
+    {
+      "type": "PivotCall",
+      "code_step": "df.pivot(index=['foo'], columns=[\"bar\", 'baz', 'zoo'])",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 54
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "foo",
+              "bar",
+              "baz",
+              "zoo"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
+          },
+          "data": [
+            [
+              "one",
+              "A",
+              1,
+              "x"
+            ],
+            [
+              "one",
+              "B",
+              2,
+              "y"
+            ],
+            [
+              "one",
+              "C",
+              3,
+              "z"
+            ],
+            [
+              "two",
+              "A",
+              4,
+              "q"
+            ],
+            [
+              "two",
+              "B",
+              5,
+              "w"
+            ],
+            [
+              "two",
+              "C",
+              6,
+              "t"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              "bar",
+              "baz",
+              "zoo"
+            ],
+            "labels": []
+          },
+          "index": {
+            "names": [
+              "foo"
+            ],
+            "labels": [
+              "one",
+              "two"
+            ]
+          },
+          "data": [
+            [],
+            []
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_02.py
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_02.py
@@ -1,0 +1,18 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+foo,bar,baz,zoo
+one,A,1,x
+one,B,2,y
+one,C,3,z
+two,A,4,q
+two,B,5,w
+two,C,6,t
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# produces an empty dataframe with original index
+df.pivot(columns=["foo", "bar", "baz", "zoo"])

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_02.py.golden
@@ -1,0 +1,121 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# produces an empty dataframe with original index\ndf.pivot(columns=[\"foo\", \"bar\", \"baz\", \"zoo\"])\n",
+  "explanation": [
+    {
+      "type": "PivotCall",
+      "code_step": "df.pivot(columns=[\"foo\", \"bar\", \"baz\", \"zoo\"])",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 46
+        }
+      },
+      "marks": [],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "foo",
+              "bar",
+              "baz",
+              "zoo"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
+          },
+          "data": [
+            [
+              "one",
+              "A",
+              1,
+              "x"
+            ],
+            [
+              "one",
+              "B",
+              2,
+              "y"
+            ],
+            [
+              "one",
+              "C",
+              3,
+              "z"
+            ],
+            [
+              "two",
+              "A",
+              4,
+              "q"
+            ],
+            [
+              "two",
+              "B",
+              5,
+              "w"
+            ],
+            [
+              "two",
+              "C",
+              6,
+              "t"
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              "foo",
+              "bar",
+              "baz",
+              "zoo"
+            ],
+            "labels": []
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
+          },
+          "data": [
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
@@ -59,6 +59,114 @@
             "select": "column",
             "level": 0
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "x",
+              "one"
+            ],
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "y",
+              "one"
+            ],
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "z",
+              "one"
+            ],
+            "column": "C"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "q",
+              "two"
+            ],
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "w",
+              "two"
+            ],
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "t",
+              "two"
+            ],
+            "column": "C"
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py
@@ -1,0 +1,18 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+foo,bar,baz,zoo
+one,A,1,x
+one,B,2,y
+one,C,3,z
+two,A,4,q
+two,B,5,w
+two,C,6,t
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# result has multiindex for both rows and columns
+df.pivot(index=["zoo", "foo"], columns="bar")

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
@@ -1,9 +1,9 @@
 {
-  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\ndf.pivot(index=\"foo\", columns=\"bar\", values=\"baz\")\n",
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nfoo,bar,baz,zoo\none,A,1,x\none,B,2,y\none,C,3,z\ntwo,A,4,q\ntwo,B,5,w\ntwo,C,6,t\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# result has multiindex for both rows and columns\ndf.pivot(index=[\"zoo\", \"foo\"], columns=\"bar\")\n",
   "explanation": [
     {
       "type": "PivotCall",
-      "code_step": "df.pivot(index=\"foo\", columns=\"bar\", values=\"baz\")",
+      "code_step": "df.pivot(index=[\"zoo\", \"foo\"], columns=\"bar\")",
       "fragment": {
         "start": {
           "line": 0,
@@ -11,7 +11,7 @@
         },
         "end": {
           "line": 0,
-          "ch": 50
+          "ch": 45
         }
       },
       "marks": [
@@ -21,7 +21,7 @@
             "type": "axis",
             "anchor": "lhs",
             "select": "column",
-            "label": "foo"
+            "label": "zoo"
           },
           "to": {
             "type": "index_level",
@@ -36,13 +36,28 @@
             "type": "axis",
             "anchor": "lhs",
             "select": "column",
+            "label": "foo"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
             "label": "bar"
           },
           "to": {
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 0
+            "level": 1
           }
         },
         {
@@ -56,8 +71,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "one",
-            "column": "A"
+            "row": [
+              "x",
+              "one"
+            ],
+            "column": [
+              "baz",
+              "A"
+            ]
           }
         },
         {
@@ -71,8 +92,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "one",
-            "column": "B"
+            "row": [
+              "y",
+              "one"
+            ],
+            "column": [
+              "baz",
+              "B"
+            ]
           }
         },
         {
@@ -86,8 +113,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "one",
-            "column": "C"
+            "row": [
+              "z",
+              "one"
+            ],
+            "column": [
+              "baz",
+              "C"
+            ]
           }
         },
         {
@@ -101,8 +134,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "two",
-            "column": "A"
+            "row": [
+              "q",
+              "two"
+            ],
+            "column": [
+              "baz",
+              "A"
+            ]
           }
         },
         {
@@ -116,8 +155,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "two",
-            "column": "B"
+            "row": [
+              "w",
+              "two"
+            ],
+            "column": [
+              "baz",
+              "B"
+            ]
           }
         },
         {
@@ -131,8 +176,14 @@
           "to": {
             "type": "cell",
             "anchor": "rhs",
-            "row": "two",
-            "column": "C"
+            "row": [
+              "t",
+              "two"
+            ],
+            "column": [
+              "baz",
+              "C"
+            ]
           }
         }
       ],
@@ -206,33 +257,86 @@
           "type": "DataFrame",
           "columns": {
             "names": [
+              null,
               "bar"
             ],
             "labels": [
-              "A",
-              "B",
-              "C"
+              [
+                "baz",
+                "A"
+              ],
+              [
+                "baz",
+                "B"
+              ],
+              [
+                "baz",
+                "C"
+              ]
             ]
           },
           "index": {
             "names": [
+              "zoo",
               "foo"
             ],
             "labels": [
-              "one",
-              "two"
+              [
+                "q",
+                "two"
+              ],
+              [
+                "t",
+                "two"
+              ],
+              [
+                "w",
+                "two"
+              ],
+              [
+                "x",
+                "one"
+              ],
+              [
+                "y",
+                "one"
+              ],
+              [
+                "z",
+                "one"
+              ]
             ]
           },
           "data": [
             [
-              1,
-              2,
-              3
+              4.0,
+              null,
+              null
             ],
             [
-              4,
-              5,
-              6
+              null,
+              null,
+              6.0
+            ],
+            [
+              null,
+              5.0,
+              null
+            ],
+            [
+              1.0,
+              null,
+              null
+            ],
+            [
+              null,
+              2.0,
+              null
+            ],
+            [
+              null,
+              null,
+              3.0
             ]
           ]
         }

--- a/pandas_tutor/tests/e2e_golden/pivot_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_values_01.py.golden
@@ -29,6 +29,186 @@
             "select": "column",
             "level": 1
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 0,
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 0,
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 1,
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 1,
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2,
+            "column": "C"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2,
+            "column": "C"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 3,
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 3,
+            "column": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 4,
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 4,
+            "column": "B"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 5,
+            "column": "C"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "foo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 5,
+            "column": "C"
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
@@ -44,6 +44,222 @@
             "select": "column",
             "level": 1
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "baz",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 0,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "zoo",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "baz",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 1,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "zoo",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "baz",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 2,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "one",
+            "column": [
+              "zoo",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "baz",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 3,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "zoo",
+              "A"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "baz",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 4,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "zoo",
+              "B"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "baz"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "baz",
+              "C"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": 5,
+            "column": "zoo"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "two",
+            "column": [
+              "zoo",
+              "C"
+            ]
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
@@ -29,6 +29,78 @@
             "select": "row",
             "level": 1
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": "weight"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "weight"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": "weight"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "weight"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": "height"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "height"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": "height"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "height"
+            ],
+            "column": "pandas.Series"
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
@@ -29,6 +29,90 @@
             "select": "row",
             "level": 1
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": [
+              "weight",
+              "kg"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "kg"
+            ],
+            "column": "weight"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": [
+              "weight",
+              "kg"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "kg"
+            ],
+            "column": "weight"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": [
+              "weight",
+              "pounds"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "pounds"
+            ],
+            "column": "weight"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": [
+              "weight",
+              "pounds"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "pounds"
+            ],
+            "column": "weight"
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
@@ -29,6 +29,254 @@
             "select": "row",
             "level": 2
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 1
+          }
         }
       ],
       "data": {
@@ -196,6 +444,246 @@
             "select": "row",
             "level": 3
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date",
+              0
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score",
+              0
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date",
+              0
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score",
+              0
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date",
+              1
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score",
+              1
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date",
+              1
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score",
+              1
+            ],
+            "column": "pandas.Series"
+          }
         }
       ],
       "data": {
@@ -323,7 +811,247 @@
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 0
+            "level": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date",
+              0
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date",
+              1
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score",
+              0
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score",
+              1
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date",
+              0
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date",
+              1
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score",
+              0
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score",
+              1
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 1
           }
         }
       ],
@@ -428,7 +1156,255 @@
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 1
+            "level": 2
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "date"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ],
+              "score"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "date"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 0
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ],
+              "score"
+            ],
+            "column": 1
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
           }
         }
       ],
@@ -525,7 +1501,255 @@
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 2
+            "level": 4
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Diner",
+            "column": [
+              0,
+              "date",
+              [
+                4,
+                2
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Diner",
+            "column": [
+              0,
+              "score",
+              [
+                4,
+                2
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Diner",
+            "column": [
+              1,
+              "date",
+              [
+                4,
+                2
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Diner",
+              [
+                4,
+                2
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Diner",
+            "column": [
+              1,
+              "score",
+              [
+                4,
+                2
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Pandas",
+            "column": [
+              0,
+              "date",
+              [
+                5,
+                4
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              0,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Pandas",
+            "column": [
+              0,
+              "score",
+              [
+                5,
+                4
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "date"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Pandas",
+            "column": [
+              1,
+              "date",
+              [
+                5,
+                4
+              ]
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "Pandas",
+              [
+                5,
+                4
+              ]
+            ],
+            "column": [
+              1,
+              "score"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "Pandas",
+            "column": [
+              1,
+              "score",
+              [
+                5,
+                4
+              ]
+            ]
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
@@ -44,6 +44,94 @@
             "select": "row",
             "level": 2
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": [
+              "weight",
+              "kg"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "weight",
+              "kg"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": [
+              "weight",
+              "kg"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "weight",
+              "kg"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "cat",
+            "column": [
+              "height",
+              "m"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "cat",
+              "height",
+              "m"
+            ],
+            "column": "pandas.Series"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": "dog",
+            "column": [
+              "height",
+              "m"
+            ]
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "dog",
+              "height",
+              "m"
+            ],
+            "column": "pandas.Series"
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
@@ -29,6 +29,90 @@
             "select": "column",
             "level": 1
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              2019,
+              "F"
+            ],
+            "column": "Count"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2019,
+            "column": [
+              "Count",
+              "F"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              2019,
+              "M"
+            ],
+            "column": "Count"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2019,
+            "column": [
+              "Count",
+              "M"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              2020,
+              "F"
+            ],
+            "column": "Count"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2020,
+            "column": [
+              "Count",
+              "F"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              2020,
+              "M"
+            ],
+            "column": "Count"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": 2020,
+            "column": [
+              "Count",
+              "M"
+            ]
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
@@ -44,6 +44,121 @@
             "select": "column",
             "level": 2
           }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "large",
+              "weekly",
+              "medium"
+            ],
+            "column": "food_cost"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "large",
+            "column": [
+              "food_cost",
+              "weekly",
+              "medium"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "medium",
+              "weekly",
+              "high"
+            ],
+            "column": "food_cost"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "medium",
+            "column": [
+              "food_cost",
+              "weekly",
+              "high"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "medium",
+              "weekly",
+              "medium"
+            ],
+            "column": "food_cost"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "medium",
+            "column": [
+              "food_cost",
+              "weekly",
+              "medium"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "small",
+              "daily",
+              "high"
+            ],
+            "column": "food_cost"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "small",
+            "column": [
+              "food_cost",
+              "daily",
+              "high"
+            ]
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "small",
+              "daily",
+              "low"
+            ],
+            "column": "food_cost"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "small",
+            "column": [
+              "food_cost",
+              "daily",
+              "low"
+            ]
+          }
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
@@ -27,7 +27,117 @@
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 0
+            "level": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "large",
+              "weekly",
+              "medium"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "large",
+              "medium"
+            ],
+            "column": "weekly"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "medium",
+              "weekly",
+              "high"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "medium",
+              "high"
+            ],
+            "column": "weekly"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "medium",
+              "weekly",
+              "medium"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "medium",
+              "medium"
+            ],
+            "column": "weekly"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "small",
+              "daily",
+              "high"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "small",
+              "high"
+            ],
+            "column": "daily"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "small",
+              "daily",
+              "low"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": [
+              "small",
+              "low"
+            ],
+            "column": "daily"
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
@@ -27,7 +27,79 @@
             "type": "index_level",
             "anchor": "rhs",
             "select": "column",
-            "level": 0
+            "level": 1
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "one",
+              "a"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "a",
+            "column": "one"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "one",
+              "b"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "b",
+            "column": "one"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "two",
+              "a"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "a",
+            "column": "two"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "cell",
+            "anchor": "lhs",
+            "row": [
+              "two",
+              "b"
+            ],
+            "column": "pandas.Series"
+          },
+          "to": {
+            "type": "cell",
+            "anchor": "rhs",
+            "row": "b",
+            "column": "two"
           }
         }
       ],

--- a/pandas_tutor/tests/test_e2e.py
+++ b/pandas_tutor/tests/test_e2e.py
@@ -4,7 +4,7 @@ import unittest
 
 from ..main import make_tutor_spec
 
-test_cases = Path(__file__).parent / 'e2e_golden'
+test_cases = Path(__file__).parent / "e2e_golden"
 
 
 class TestEndToEnd(unittest.TestCase):
@@ -12,8 +12,8 @@ class TestEndToEnd(unittest.TestCase):
 
 
 def make_test_case(test_name):
-    in_file = test_cases / f'{test_name}.py'
-    golden_file = test_cases / f'{test_name}.py.golden'
+    in_file = test_cases / f"{test_name}.py"
+    golden_file = test_cases / f"{test_name}.py.golden"
 
     def test(self: TestEndToEnd):
         self.assertTrue(in_file.exists())
@@ -33,9 +33,9 @@ def make_test_case(test_name):
 
 # make all test cases dynamically!
 for test_name in test_cases.iterdir():
-    if test_name.suffix == '.py':
-        if os.environ.get('CI', False) and test_name.stem.startswith('plot_'):
+    if test_name.suffix == ".py":
+        if os.environ.get("CI", False) and test_name.stem.startswith("plot_"):
             # skip plotting test cases since gzipping isn't deterministic
             continue
         test_case = make_test_case(test_name.stem)
-        setattr(TestEndToEnd, f'test_{test_name.stem}', test_case)
+        setattr(TestEndToEnd, f"test_{test_name.stem}", test_case)

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -75,16 +75,36 @@ def listify(obj: Any) -> List:
     return obj if is_list_like(obj) else [obj]
 
 
-def unwrap(obj: Sequence[T]) -> Union[Sequence[T], T]:
+def tuplify(obj: Any) -> Tuple:
+    """if obj is a scalar, returns (obj, )"""
+    return obj if is_list_like(obj) else (obj,)
+
+
+@overload
+def unwrap(obj: Tuple[T]) -> Union[Tuple[T], T]:
+    ...
+
+
+@overload
+def unwrap(obj: List[T]) -> Union[List[T], T]:
+    ...
+
+
+@overload
+def unwrap(obj: Label) -> Label:
+    ...
+
+
+def unwrap(obj):
     """unwrap obj if single element"""
-    return obj[0] if len(obj) == 1 else obj
+    return obj if not is_list_like(obj) else obj[0] if len(obj) == 1 else obj
 
 
 def split_by(
     seq: Sequence[T], indexes: Sequence[int]
 ) -> Tuple[Tuple[T, ...], Tuple[T, ...]]:
     """
-    returns two tuple, one with the elements at the given indexes, and one
+    returns two tuples, one with the elements at the given indexes, and one
     with the rest of the elements.
     """
     # can't use sets since we need to preserve order
@@ -269,30 +289,37 @@ def level_number(index: pd.Index, level: str | int) -> int:
 _MultiLabelPair = Tuple[Tuple[Label, ...], Tuple[Label, ...]]
 
 
+def cell_labels(
+    index1: Iterable[Label], index2: Iterable[Label]
+) -> Tuple[LabelPair]:
+    """returns (row, column) labels"""
+    return tuple(itertools.product(index1, index2))  # type: ignore
+
+
 def push_levels(
-    from_: pd.Index, to: pd.Index, levels: List[int]
+    from_: Iterable[Label], to: Iterable[Label], levels: List[int]
 ) -> Iterable[Tuple[LabelPair, LabelPair]]:
     """
-    pushes levels from index1 to index2. used to map cells during reshaping
-    operations. returns original and new label pairs.
+    pushes levels from_ -> to. used to map cells during reshaping operations.
+    returns original and new label pairs.
     """
-    orig_cells = list(itertools.product(from_, to))
+    orig = cell_labels(from_, to)
 
     # if we're pushing into a series, we need to handle the placeholder
-    iter_to = to if SERIES not in to else [[]]
+    iter_to = to if SERIES not in to else [tuple()]
 
     # wrap values in tuples to make iteration easier
     wrapped_orig = cast(
         List[_MultiLabelPair],
-        list(itertools.product(map(listify, from_), map(listify, iter_to))),
+        list(itertools.product(map(tuplify, from_), map(tuplify, iter_to))),
     )
 
-    new_cells: List[LabelPair] = []
+    new: List[LabelPair] = []
     for left, right in wrapped_orig:
         move, stay = split_by(left, levels)
-        new_cells.append(mapt(unwrap, (stay, (*right, *move))))
+        new.append(mapt(unwrap, (stay, (*right, *move))))
 
-    return zip(orig_cells, new_cells)
+    return zip(orig, new)
 
 
 @overload

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -7,32 +7,48 @@ import base64
 import dataclasses
 import io
 import itertools
-import typing as t
-from typing_extensions import TypeGuard
 import warnings
-from collections import abc
+from collections.abc import Iterable, Sequence
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 from warnings import warn
 
 import numpy as np
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy, SeriesGroupBy
 from pandas.core.groupby.groupby import GroupBy
+from typing_extensions import TypeGuard
 
-Axis = t.Literal["index", "columns"]
-Slicer = t.Literal["loc", "iloc", None]
+T = TypeVar("T")
+
+Axis = Literal["index", "columns"]
+Slicer = Literal["loc", "iloc", None]
 
 # A Label is a value that came from pandas Index. It's a tuple of values
 # if we have a multi-index, or a single value otherwise.
 #
 # technically dataframe labels can be all sorts of things...
 # TODO: handle other index dtypes, like datetimes
-Label = t.Union[int, str, tuple]
+Label = Union[int, str, tuple]
+LabelPair = Tuple[Label, Label]
 
-HasIndex = t.Union[pd.DataFrame, pd.Series]
+HasIndex = Union[pd.DataFrame, pd.Series]
 
-Groups = t.Dict[t.Union[str, tuple], pd.Index]
+Groups = Dict[Union[str, tuple], pd.Index]
 
-JSONScalar = t.Union[int, float, str, bool, None]
+JSONScalar = Union[int, float, str, bool, None]
+
+# placeholder column for pd.Series
+SERIES = "pandas.Series"
 
 
 def mapt(fn, *args):
@@ -45,18 +61,35 @@ def flatmap(fn, *args):
     return itertools.chain.from_iterable(map(fn, *args))
 
 
-def is_list_like(obj: t.Any) -> bool:
+def is_list_like(obj: Any) -> bool:
     """
     checks whether obj is a list-like. we need this because we don't usually
     want to do list(string), but we want to convert other types of list-like
     things to lists
     """
-    return not isinstance(obj, str) and isinstance(obj, abc.Iterable)
+    return not isinstance(obj, str) and isinstance(obj, Iterable)
 
 
-def listify(obj: t.Any) -> t.List:
+def listify(obj: Any) -> List:
     """if obj is a scalar, returns [obj]"""
     return obj if is_list_like(obj) else [obj]
+
+
+def unwrap(obj: Sequence[T]) -> Union[Sequence[T], T]:
+    """unwrap obj if single element"""
+    return obj[0] if len(obj) == 1 else obj
+
+
+def split_by(
+    seq: Sequence[T], indexes: Sequence[int]
+) -> Tuple[Tuple[T, ...], Tuple[T, ...]]:
+    """
+    returns two tuple, one with the elements at the given indexes, and one
+    with the rest of the elements.
+    """
+    # can't use sets since we need to preserve order
+    not_in = [i for i in range(len(seq)) if i not in indexes]
+    return tuple(seq[i] for i in indexes), tuple(seq[i] for i in not_in)
 
 
 @dataclasses.dataclass
@@ -138,9 +171,9 @@ class CodeRange:
 ##############################################################################
 
 
-@t.overload
+@overload
 def positions_to_labels(
-    positions: t.Union[int, Label],
+    positions: Union[int, Label],
     df: HasIndex,
     slicer: Slicer = "iloc",
     axis: Axis = "index",
@@ -148,13 +181,13 @@ def positions_to_labels(
     ...
 
 
-@t.overload
+@overload
 def positions_to_labels(  # noqa: F811
     positions: list,  # type: ignore
     df: HasIndex,
     slicer: Slicer = "iloc",
     axis: Axis = "index",
-) -> t.List[Label]:
+) -> List[Label]:
     ...
 
 
@@ -175,7 +208,7 @@ def positions_to_labels(  # noqa: F811
         warn("tried to convert column labels for a series")
         return positions
 
-    labels = t.cast(pd.Index, df.columns if axis == "columns" else df.index)
+    labels = cast(pd.Index, df.columns if axis == "columns" else df.index)
     return labels[positions]
 
 
@@ -211,11 +244,11 @@ def match_cols(
     )
 
 
-def is_series(obj: t.Any) -> TypeGuard[pd.Series]:
+def is_series(obj: Any) -> TypeGuard[pd.Series]:
     return isinstance(obj, pd.Series)
 
 
-def is_dataframe(obj: t.Any) -> TypeGuard[pd.DataFrame]:
+def is_dataframe(obj: Any) -> TypeGuard[pd.DataFrame]:
     return isinstance(obj, pd.DataFrame)
 
 
@@ -223,19 +256,53 @@ def is_multi(index: pd.Index) -> TypeGuard[pd.MultiIndex]:
     return isinstance(index, pd.MultiIndex)
 
 
-def level_as_int(index: pd.Index, level: str | int) -> int:
+def level_number(index: pd.Index, level: str | int) -> int:
     "converts a name of a level to the level's integer index if needed"
-    return index.names.index(level) if isinstance(level, str) else level
+    return (
+        index.names.index(level)
+        if isinstance(level, str)
+        else level % len(index.names)
+    )
 
 
-@t.overload
-def ungroup(obj: t.Union[SeriesGroupBy, pd.Series]) -> pd.Series:
+# pair of multi-index labels
+_MultiLabelPair = Tuple[Tuple[Label, ...], Tuple[Label, ...]]
+
+
+def push_levels(
+    from_: pd.Index, to: pd.Index, levels: List[int]
+) -> Iterable[Tuple[LabelPair, LabelPair]]:
+    """
+    pushes levels from index1 to index2. used to map cells during reshaping
+    operations. returns original and new label pairs.
+    """
+    orig_cells = list(itertools.product(from_, to))
+
+    # if we're pushing into a series, we need to handle the placeholder
+    iter_to = to if SERIES not in to else [[]]
+
+    # wrap values in tuples to make iteration easier
+    wrapped_orig = cast(
+        List[_MultiLabelPair],
+        list(itertools.product(map(listify, from_), map(listify, iter_to))),
+    )
+
+    new_cells: List[LabelPair] = []
+    for left, right in wrapped_orig:
+        move, stay = split_by(left, levels)
+        new_cells.append(mapt(unwrap, (stay, (*right, *move))))
+
+    return zip(orig_cells, new_cells)
+
+
+@overload
+def ungroup(obj: Union[SeriesGroupBy, pd.Series]) -> pd.Series:
     ...
 
 
-@t.overload
+@overload
 def ungroup(  # type: ignore # noqa: F811
-    obj: t.Union[DataFrameGroupBy, pd.DataFrame]  # noqa: F811
+    obj: Union[DataFrameGroupBy, pd.DataFrame]  # noqa: F811
 ) -> pd.DataFrame:
     ...
 
@@ -253,7 +320,7 @@ def ungroup(obj):  # noqa: F811
     # return groupby.transform(lambda x: x)
 
 
-def grouping_labels(groupby: GroupBy) -> t.List[Label]:
+def grouping_labels(groupby: GroupBy) -> List[Label]:
     """gets ['hello', 'world'] from df.groupby(['hello', 'world'])"""
     # NOTE: when grouping by unnamed sequences, names will contain None
     # >>> full.groupby([test, test2]).grouper.names
@@ -261,28 +328,28 @@ def grouping_labels(groupby: GroupBy) -> t.List[Label]:
     return groupby.grouper.names
 
 
-def get_groups(groupby: t.Union[SeriesGroupBy, DataFrameGroupBy]) -> Groups:
+def get_groups(groupby: Union[SeriesGroupBy, DataFrameGroupBy]) -> Groups:
     """
     gets mapping of group keys -> dataframe labels.
     """
     # when the group keys includes NaN, groupby.groups freaks out, so we use a
     # workaround by getting the group indices first, then recovering the labels
     try:
-        return t.cast(Groups, groupby.groups)
+        return cast(Groups, groupby.groups)
     except ValueError:
         index = ungroup(groupby).index
         groups = {
             key: index[indices] for key, indices in groupby.indices.items()
         }
-        return t.cast(Groups, groups)
+        return cast(Groups, groups)
 
 
-def is_plottable(obj: t.Any) -> bool:
+def is_plottable(obj: Any) -> bool:
     fig = obj.figure if hasattr(obj, "figure") else obj
     return hasattr(fig, "savefig")
 
 
-def base64_encode_plot(fig_or_axes: t.Any) -> str:
+def base64_encode_plot(fig_or_axes: Any) -> str:
     """
     saves plot as a gzipped, base64 encoded png
     """
@@ -300,7 +367,7 @@ def base64_encode_plot(fig_or_axes: t.Any) -> str:
         return base64.b64encode(buf.read()).decode()
 
 
-def json_scalar(obj: t.Any) -> JSONScalar:
+def json_scalar(obj: Any) -> JSONScalar:
     """
     transforms special pandas / numpy value to a value that can be
     serialized to json
@@ -324,11 +391,11 @@ def json_scalar(obj: t.Any) -> JSONScalar:
     return obj
 
 
-def prep_series_data(series: pd.Series) -> t.List[JSONScalar]:
+def prep_series_data(series: pd.Series) -> List[JSONScalar]:
     return [json_scalar(val) for val in series.to_numpy()]
 
 
-def prep_df_data(df: pd.DataFrame) -> t.List[t.List[JSONScalar]]:
+def prep_df_data(df: pd.DataFrame) -> List[List[JSONScalar]]:
     return [[json_scalar(val) for val in row] for row in df.to_numpy()]
 
 
@@ -337,7 +404,7 @@ def prep_df_data(df: pd.DataFrame) -> t.List[t.List[JSONScalar]]:
 ##############################################################################
 
 
-def mem_used(obj: t.Any) -> float:
+def mem_used(obj: Any) -> float:
     if isinstance(obj, pd.DataFrame):
         return obj.memory_usage(deep=True).sum()
     elif isinstance(obj, pd.Series):


### PR DESCRIPTION
`stack()`, `unstack()` and `pivot()` now produce cell-to-cell mappings. 

for example, the cell labeled `(0, 'baz')` gets mapped to `('one', 'A')` in this pivot:

![image](https://user-images.githubusercontent.com/2468904/159826559-d9cd68e1-7b91-49e1-8726-ca2f9f5d9ded.png)

the resulting JSON looks like:

https://github.com/SamLau95/pandas_tutor/blob/bc08f668ebcb8a9fffc0c0b5abe1cb97c5f530cc/pandas_tutor/tests/e2e_golden/pivot_basic_01.py.golden#L48-L62