### PR TITLE
sets of cell mappings for reshape operations

### DIFF
--- a/pandas_tutor/diagram.py
+++ b/pandas_tutor/diagram.py
@@ -206,7 +206,7 @@ class CellPos(TablePos):
 ##############################################################################
 
 # each Mark object is serialized as one of these
-MarkType = t.Literal["using", "map", "drop"]
+MarkType = t.Literal["using", "map", "map_set", "drop"]
 
 
 @dataclasses.dataclass
@@ -241,6 +241,20 @@ class Map(Mark):
 
     def __post_init__(self):
         self.type = "map"
+
+
+@dataclasses.dataclass
+class MapSet(Mark):
+    """
+    represents a set of Map objects. the frontend uses this to simplify the
+    visualization when there are many small marks to visualize (e.g. many
+    cell-to-cell mappings).
+    """
+
+    maps: t.List[Map]
+
+    def __post_init__(self):
+        self.type = "map_set"
 
 
 @dataclasses.dataclass

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -1,9 +1,9 @@
 """
 creates mark specs. here's where the magic happens!
 """
+import itertools
 from collections.abc import Iterable
 from typing import Any, List, Optional, Tuple, Union, cast
-from collections.abc import Sequence
 
 import pandas as pd
 
@@ -16,6 +16,7 @@ from .diagram import (
     IndexLevel,
     IndexLevelPos,
     Map,
+    MapSet,
     Mark,
     Selection,
     SeriesPos,
@@ -374,15 +375,24 @@ def mark_for_stack(
     # for each cell: the unstacked labels move to the row index
     is_series = isinstance(after, SeriesResult)
     cells = util.push_levels(df.columns, df.index, levels)
-    cell_marks: List[Mark] = [
-        Map(
+
+    pairs = [
+        (
             CellPos("lhs", old_row, old_col),
             CellPos("rhs", new_row, new_col if not is_series else util.SERIES),
         )
         for (old_col, old_row), (new_col, new_row) in cells
     ]
+    pairs = sorted(pairs, key=by_row)
 
-    return [*index_marks, *cell_marks]
+    # group together marks that map the same row to show the reshapings on a
+    # smaller scale
+    cell_sets = [
+        MapSet([Map(from_, to) for from_, to in g])
+        for _, g in itertools.groupby(pairs, key=by_row)
+    ]
+
+    return [*index_marks, *cell_sets]
 
 
 # df.pivot(index='foo', columns='bar', values='baz')
@@ -700,3 +710,15 @@ def lhs_series() -> SeriesPos:
 def rhs_series() -> SeriesPos:
     """shorthand for the rhs series"""
     return SeriesPos("rhs")
+
+
+def by_row(pair: Tuple[CellPos, CellPos]) -> util.Label:
+    """grouper for CellPos pairs. returns the row label of the original cell"""
+    cell, _ = pair
+    return cell.row
+
+
+def by_column(pair: Tuple[CellPos, CellPos]) -> util.Label:
+    """grouper for CellPos pairs. returns the col label of the original cell"""
+    cell, _ = pair
+    return cell.column

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -337,12 +337,19 @@ def mark_for_unstack(
 
     # for each cell: the unstacked labels move to the column index
     cells = util.push_levels(df.index, columns, levels)
-    cell_marks: List[Mark] = [
-        Map(CellPos("lhs", old_row, old_col), CellPos("rhs", new_row, new_col))
+    pairs = [
+        (CellPos("lhs", old_row, old_col), CellPos("rhs", new_row, new_col))
         for (old_row, old_col), (new_row, new_col) in cells
     ]
+    pairs = sorted(pairs, key=by_column)
 
-    return [*index_marks, *cell_marks]
+    # group together marks that map the same column
+    cell_sets = [
+        MapSet([Map(from_, to) for from_, to in g])
+        for _, g in itertools.groupby(pairs, key=by_column)
+    ]
+
+    return [*index_marks, *cell_sets]
 
 
 # counts.stack(level=-1, drop_na=False)
@@ -375,7 +382,6 @@ def mark_for_stack(
     # for each cell: the unstacked labels move to the row index
     is_series = isinstance(after, SeriesResult)
     cells = util.push_levels(df.columns, df.index, levels)
-
     pairs = [
         (
             CellPos("lhs", old_row, old_col),
@@ -385,8 +391,7 @@ def mark_for_stack(
     ]
     pairs = sorted(pairs, key=by_row)
 
-    # group together marks that map the same row to show the reshapings on a
-    # smaller scale
+    # group together marks that map the same row
     cell_sets = [
         MapSet([Map(from_, to) for from_, to in g])
         for _, g in itertools.groupby(pairs, key=by_row)

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -449,7 +449,7 @@ def mark_for_pivot(
 
     # to make cell marks, we need to pull row and column labels from the data
     # rows themselves so the logic is tricky
-    cell_marks = []
+    pairs = []
     for old_row, row in df.iterrows():
         old_row = cast(util.Label, old_row)
         # pull new row labels from row data
@@ -461,9 +461,16 @@ def mark_for_pivot(
             new_col = (old_col, *appended) if not will_drop_values else appended
             left = CellPos("lhs", old_row, old_col)
             right = CellPos("rhs", new_row, new_col)
-            cell_marks.append(Map(left, right))
+            pairs.append((left, right))
 
-    return [*index_marks, *column_marks, *cell_marks]
+    # group together marks using their original columns
+    pairs = sorted(pairs, key=by_column)
+    cell_sets = [
+        MapSet([Map(from_, to) for from_, to in g])
+        for _, g in itertools.groupby(pairs, key=by_column)
+    ]
+
+    return [*index_marks, *column_marks, *cell_sets]
 
 
 # handler for all subscripts, like:

--- a/pandas_tutor/tests/e2e_golden/pivot_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_basic_01.py.golden
@@ -46,94 +46,99 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": "A"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": "B"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": "C"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": "A"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": "B"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": "C"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": "C"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": "C"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_columns_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_columns_01.py.golden
@@ -46,232 +46,242 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 0,
-            "column": [
-              "baz",
-              "one",
-              "A"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 0,
+                "column": [
+                  "baz",
+                  "one",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 1,
+                "column": [
+                  "baz",
+                  "one",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2,
+                "column": [
+                  "baz",
+                  "one",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 3,
+                "column": [
+                  "baz",
+                  "two",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 4,
+                "column": [
+                  "baz",
+                  "two",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 5,
+                "column": [
+                  "baz",
+                  "two",
+                  "C"
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 0,
-            "column": [
-              "zoo",
-              "one",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 1,
-            "column": [
-              "baz",
-              "one",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 1,
-            "column": [
-              "zoo",
-              "one",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2,
-            "column": [
-              "baz",
-              "one",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2,
-            "column": [
-              "zoo",
-              "one",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 3,
-            "column": [
-              "baz",
-              "two",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 3,
-            "column": [
-              "zoo",
-              "two",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 4,
-            "column": [
-              "baz",
-              "two",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 4,
-            "column": [
-              "zoo",
-              "two",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 5,
-            "column": [
-              "baz",
-              "two",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 5,
-            "column": [
-              "zoo",
-              "two",
-              "C"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 0,
+                "column": [
+                  "zoo",
+                  "one",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 1,
+                "column": [
+                  "zoo",
+                  "one",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2,
+                "column": [
+                  "zoo",
+                  "one",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 3,
+                "column": [
+                  "zoo",
+                  "two",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 4,
+                "column": [
+                  "zoo",
+                  "two",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 5,
+                "column": [
+                  "zoo",
+                  "two",
+                  "C"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
@@ -61,112 +61,117 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "x",
-              "one"
-            ],
-            "column": "A"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "y",
-              "one"
-            ],
-            "column": "B"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "z",
-              "one"
-            ],
-            "column": "C"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "q",
-              "two"
-            ],
-            "column": "A"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "w",
-              "two"
-            ],
-            "column": "B"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "t",
-              "two"
-            ],
-            "column": "C"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "x",
+                  "one"
+                ],
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "y",
+                  "one"
+                ],
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "z",
+                  "one"
+                ],
+                "column": "C"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "q",
+                  "two"
+                ],
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "w",
+                  "two"
+                ],
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "t",
+                  "two"
+                ],
+                "column": "C"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
@@ -61,130 +61,135 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "x",
-              "one"
-            ],
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "y",
-              "one"
-            ],
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "z",
-              "one"
-            ],
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "q",
-              "two"
-            ],
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "w",
-              "two"
-            ],
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "t",
-              "two"
-            ],
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "x",
+                  "one"
+                ],
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "y",
+                  "one"
+                ],
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "z",
+                  "one"
+                ],
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "q",
+                  "two"
+                ],
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "w",
+                  "two"
+                ],
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "t",
+                  "two"
+                ],
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_values_01.py.golden
@@ -31,220 +31,230 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 0,
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 0,
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 1,
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2,
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 3,
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 4,
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 5,
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 0,
-            "column": [
-              "foo",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 1,
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 1,
-            "column": [
-              "foo",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2,
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2,
-            "column": [
-              "foo",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 3,
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 3,
-            "column": [
-              "foo",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 4,
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 4,
-            "column": [
-              "foo",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 5,
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "foo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 5,
-            "column": [
-              "foo",
-              "C"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 0,
+                "column": [
+                  "foo",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 1,
+                "column": [
+                  "foo",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2,
+                "column": [
+                  "foo",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 3,
+                "column": [
+                  "foo",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 4,
+                "column": [
+                  "foo",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "foo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 5,
+                "column": [
+                  "foo",
+                  "C"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
@@ -46,220 +46,230 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "baz",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "baz",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "baz"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "baz",
+                  "C"
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 0,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "zoo",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 1,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "zoo",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 2,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "one",
-            "column": [
-              "zoo",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "baz",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 3,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "zoo",
-              "A"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "baz",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 4,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "zoo",
-              "B"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "baz"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "baz",
-              "C"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": 5,
-            "column": "zoo"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "two",
-            "column": [
-              "zoo",
-              "C"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "zoo",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "zoo",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "one",
+                "column": [
+                  "zoo",
+                  "C"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "zoo",
+                  "A"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "zoo",
+                  "B"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "zoo"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "two",
+                "column": [
+                  "zoo",
+                  "C"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
@@ -31,76 +31,86 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": "weight"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "weight"
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": "weight"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "weight"
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": "height"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "height"
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": "weight"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "weight"
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": "height"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "height"
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": "height"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "height"
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": "weight"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "weight"
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": "height"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "height"
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
@@ -31,88 +31,98 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": [
-              "weight",
-              "kg"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "kg"
-            ],
-            "column": "weight"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": [
+                  "weight",
+                  "kg"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "kg"
+                ],
+                "column": "weight"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": [
+                  "weight",
+                  "pounds"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "pounds"
+                ],
+                "column": "weight"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": [
-              "weight",
-              "kg"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "kg"
-            ],
-            "column": "weight"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": [
-              "weight",
-              "pounds"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "pounds"
-            ],
-            "column": "weight"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": [
-              "weight",
-              "pounds"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "pounds"
-            ],
-            "column": "weight"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": [
+                  "weight",
+                  "kg"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "kg"
+                ],
+                "column": "weight"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": [
+                  "weight",
+                  "pounds"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "pounds"
+                ],
+                "column": "weight"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
@@ -845,244 +845,249 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date",
-              0
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date",
-              1
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score",
-              0
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score",
-              1
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date",
-              0
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date",
-              1
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score",
-              0
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score",
-              1
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 1
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date",
+                  0
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date",
+                  1
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 1
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score",
+                  0
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score",
+                  1
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 1
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date",
+                  0
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date",
+                  1
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 1
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score",
+                  0
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score",
+                  1
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 1
+              }
+            }
+          ]
         }
       ],
       "data": {
@@ -1190,252 +1195,262 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {
@@ -1535,252 +1550,272 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Diner",
-            "column": [
-              0,
-              "date",
-              [
-                4,
-                2
-              ]
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Diner",
+                "column": [
+                  0,
+                  "date",
+                  [
+                    4,
+                    2
+                  ]
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Pandas",
+                "column": [
+                  0,
+                  "date",
+                  [
+                    5,
+                    4
+                  ]
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Diner",
-            "column": [
-              0,
-              "score",
-              [
-                4,
-                2
-              ]
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Diner",
+                "column": [
+                  0,
+                  "score",
+                  [
+                    4,
+                    2
+                  ]
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Pandas",
+                "column": [
+                  0,
+                  "score",
+                  [
+                    5,
+                    4
+                  ]
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Diner",
-            "column": [
-              1,
-              "date",
-              [
-                4,
-                2
-              ]
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Diner",
+                "column": [
+                  1,
+                  "date",
+                  [
+                    4,
+                    2
+                  ]
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Pandas",
+                "column": [
+                  1,
+                  "date",
+                  [
+                    5,
+                    4
+                  ]
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Diner",
-            "column": [
-              1,
-              "score",
-              [
-                4,
-                2
-              ]
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Pandas",
-            "column": [
-              0,
-              "date",
-              [
-                5,
-                4
-              ]
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Pandas",
-            "column": [
-              0,
-              "score",
-              [
-                5,
-                4
-              ]
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Pandas",
-            "column": [
-              1,
-              "date",
-              [
-                5,
-                4
-              ]
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "Pandas",
-            "column": [
-              1,
-              "score",
-              [
-                5,
-                4
-              ]
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Diner",
+                "column": [
+                  1,
+                  "score",
+                  [
+                    4,
+                    2
+                  ]
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "Pandas",
+                "column": [
+                  1,
+                  "score",
+                  [
+                    5,
+                    4
+                  ]
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
@@ -31,252 +31,262 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 0
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 1
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 1
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              0,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 0
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "score"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 1
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ]
-            ],
-            "column": [
-              1,
-              "date"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 1
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  0,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 0
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "score"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 1
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ]
+                ],
+                "column": [
+                  1,
+                  "date"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 1
+              }
+            }
+          ]
         }
       ],
       "data": {
@@ -446,244 +456,264 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date",
-              0
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date",
+                  0
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "date",
+                  1
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score",
-              0
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score",
+                  0
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Diner",
+                  [
+                    4,
+                    2
+                  ],
+                  "score",
+                  1
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date",
-              0
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date",
+                  0
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "date",
+                  1
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 0
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score",
-              0
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "date",
-              1
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Diner",
-              [
-                4,
-                2
-              ],
-              "score",
-              1
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "date",
-              1
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score"
-            ],
-            "column": 1
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "Pandas",
-              [
-                5,
-                4
-              ],
-              "score",
-              1
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 0
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score",
+                  0
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score"
+                ],
+                "column": 1
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "Pandas",
+                  [
+                    5,
+                    4
+                  ],
+                  "score",
+                  1
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
@@ -46,92 +46,102 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": [
-              "weight",
-              "kg"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "weight",
-              "kg"
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": [
+                  "weight",
+                  "kg"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "weight",
+                  "kg"
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "cat",
+                "column": [
+                  "height",
+                  "m"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "cat",
+                  "height",
+                  "m"
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": [
-              "weight",
-              "kg"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "weight",
-              "kg"
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "cat",
-            "column": [
-              "height",
-              "m"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "cat",
-              "height",
-              "m"
-            ],
-            "column": "pandas.Series"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": "dog",
-            "column": [
-              "height",
-              "m"
-            ]
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "dog",
-              "height",
-              "m"
-            ],
-            "column": "pandas.Series"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": [
+                  "weight",
+                  "kg"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "weight",
+                  "kg"
+                ],
+                "column": "pandas.Series"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": "dog",
+                "column": [
+                  "height",
+                  "m"
+                ]
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "dog",
+                  "height",
+                  "m"
+                ],
+                "column": "pandas.Series"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
@@ -31,88 +31,93 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              2019,
-              "F"
-            ],
-            "column": "Count"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2019,
-            "column": [
-              "Count",
-              "F"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              2019,
-              "M"
-            ],
-            "column": "Count"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2019,
-            "column": [
-              "Count",
-              "M"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              2020,
-              "F"
-            ],
-            "column": "Count"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2020,
-            "column": [
-              "Count",
-              "F"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              2020,
-              "M"
-            ],
-            "column": "Count"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": 2020,
-            "column": [
-              "Count",
-              "M"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  2019,
+                  "F"
+                ],
+                "column": "Count"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2019,
+                "column": [
+                  "Count",
+                  "F"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  2019,
+                  "M"
+                ],
+                "column": "Count"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2019,
+                "column": [
+                  "Count",
+                  "M"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  2020,
+                  "F"
+                ],
+                "column": "Count"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2020,
+                "column": [
+                  "Count",
+                  "F"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  2020,
+                  "M"
+                ],
+                "column": "Count"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": 2020,
+                "column": [
+                  "Count",
+                  "M"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
@@ -46,119 +46,124 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "large",
-              "weekly",
-              "medium"
-            ],
-            "column": "food_cost"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "large",
-            "column": [
-              "food_cost",
-              "weekly",
-              "medium"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "medium",
-              "weekly",
-              "high"
-            ],
-            "column": "food_cost"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "medium",
-            "column": [
-              "food_cost",
-              "weekly",
-              "high"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "medium",
-              "weekly",
-              "medium"
-            ],
-            "column": "food_cost"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "medium",
-            "column": [
-              "food_cost",
-              "weekly",
-              "medium"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "small",
-              "daily",
-              "high"
-            ],
-            "column": "food_cost"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "small",
-            "column": [
-              "food_cost",
-              "daily",
-              "high"
-            ]
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "small",
-              "daily",
-              "low"
-            ],
-            "column": "food_cost"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "small",
-            "column": [
-              "food_cost",
-              "daily",
-              "low"
-            ]
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "large",
+                  "weekly",
+                  "medium"
+                ],
+                "column": "food_cost"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": [
+                  "food_cost",
+                  "weekly",
+                  "medium"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "medium",
+                  "weekly",
+                  "high"
+                ],
+                "column": "food_cost"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "medium",
+                "column": [
+                  "food_cost",
+                  "weekly",
+                  "high"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "medium",
+                  "weekly",
+                  "medium"
+                ],
+                "column": "food_cost"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "medium",
+                "column": [
+                  "food_cost",
+                  "weekly",
+                  "medium"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "small",
+                  "daily",
+                  "high"
+                ],
+                "column": "food_cost"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": [
+                  "food_cost",
+                  "daily",
+                  "high"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "small",
+                  "daily",
+                  "low"
+                ],
+                "column": "food_cost"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": [
+                  "food_cost",
+                  "daily",
+                  "low"
+                ]
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
@@ -31,114 +31,119 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "large",
-              "weekly",
-              "medium"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "large",
-              "medium"
-            ],
-            "column": "weekly"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "medium",
-              "weekly",
-              "high"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "medium",
-              "high"
-            ],
-            "column": "weekly"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "medium",
-              "weekly",
-              "medium"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "medium",
-              "medium"
-            ],
-            "column": "weekly"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "small",
-              "daily",
-              "high"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "small",
-              "high"
-            ],
-            "column": "daily"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "small",
-              "daily",
-              "low"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": [
-              "small",
-              "low"
-            ],
-            "column": "daily"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "large",
+                  "weekly",
+                  "medium"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "large",
+                  "medium"
+                ],
+                "column": "weekly"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "medium",
+                  "weekly",
+                  "high"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "medium",
+                  "high"
+                ],
+                "column": "weekly"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "medium",
+                  "weekly",
+                  "medium"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "medium",
+                  "medium"
+                ],
+                "column": "weekly"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "small",
+                  "daily",
+                  "high"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "small",
+                  "high"
+                ],
+                "column": "daily"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "small",
+                  "daily",
+                  "low"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "small",
+                  "low"
+                ],
+                "column": "daily"
+              }
+            }
+          ]
         }
       ],
       "data": {

--- a/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
@@ -31,76 +31,81 @@
           }
         },
         {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "one",
-              "a"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "a",
-            "column": "one"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "one",
-              "b"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "b",
-            "column": "one"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "two",
-              "a"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "a",
-            "column": "two"
-          }
-        },
-        {
-          "type": "map",
-          "from": {
-            "type": "cell",
-            "anchor": "lhs",
-            "row": [
-              "two",
-              "b"
-            ],
-            "column": "pandas.Series"
-          },
-          "to": {
-            "type": "cell",
-            "anchor": "rhs",
-            "row": "b",
-            "column": "two"
-          }
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "one",
+                  "a"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "a",
+                "column": "one"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "one",
+                  "b"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "b",
+                "column": "one"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "two",
+                  "a"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "a",
+                "column": "two"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": [
+                  "two",
+                  "b"
+                ],
+                "column": "pandas.Series"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "b",
+                "column": "two"
+              }
+            }
+          ]
         }
       ],
       "data": {


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/120

this pr adds `MapSet`, a new kind of mark that holds a list of `Map` marks.

we now use these to mark sets of cell mappings so that the frontend can color them all using the same shade, like the pandas docs (https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-stacking-and-unstacking)

`MapSet` holds a list of individual `Map` objects for flexibility. although we don't plan to show cell-to-cell arrows for now, we might want to in the future (e.g. when a user mouses over an individual cell). this schema lets the frontend choose whether it wants to show cell-to-cell arrows or not.

https://github.com/SamLau95/pandas_tutor/blob/62f0301329a12624ac1365bbb198f7df954dea03/pandas_tutor/diagram.py#L246-L257

`stack()`, `unstack()`, and `pivot()` now use `MapSet`. for example:

https://github.com/SamLau95/pandas_tutor/blob/62f0301329a12624ac1365bbb198f7df954dea03/pandas_tutor/tests/e2e_golden/pivot_columns_01.py#L15-L17

https://github.com/SamLau95/pandas_tutor/blob/62f0301329a12624ac1365bbb198f7df954dea03/pandas_tutor/tests/e2e_golden/pivot_columns_01.py.golden#L48-L166