### PR TITLE
pivot_table()

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -477,7 +477,6 @@ def mark_for_pivot_table(
     args = after.args
 
     has_index = "index" in args
-    has_columns = "columns" in args
     has_values = "values" in args
     index: List[Label] = util.listify(args.get("index", []))
     columns: List[Label] = util.listify(args.get("columns", []))
@@ -567,9 +566,6 @@ def mark_for_pivot_table(
     # mapset for pivot_table() is more granular than pivot() since we want
     # to show each individual aggregation
     cell_sets = make_cell_sets(pairs, key=by_result_cell)
-
-    util.print_mapsets(cell_sets)
-    breakpoint()
 
     return [*index_marks, *column_marks, *cell_sets]
 

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -3,7 +3,7 @@ creates mark specs. here's where the magic happens!
 """
 import itertools
 from collections.abc import Iterable
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
 import pandas as pd
 
@@ -34,6 +34,7 @@ from .parse_nodes import (
     HeadCall,
     PassThroughCall,
     PivotCall,
+    PivotTableCall,
     RenameCall,
     ResetIndexCall,
     SortValuesCall,
@@ -52,6 +53,7 @@ from .run import (
     SeriesGroupbyResult,
     SeriesResult,
 )
+from .util import SERIES, Label, LabelPair
 
 
 # step comes from after.step, but we pull it out here to help with
@@ -91,6 +93,8 @@ def make_marks(
         return mark_for_stack(step, before, after)
     elif isinstance(step, PivotCall):
         return mark_for_pivot(step, before, after)
+    elif isinstance(step, PivotTableCall):
+        return mark_for_pivot_table(step, before, after)
     elif isinstance(step, Subscript):
         return mark_for_subscript(step, before, after)
     else:
@@ -116,10 +120,10 @@ def mark_for_sort_values(
     sorted_labels = df.index if step.axis == "index" else df.columns
 
     # highlight sorted cols in RHS since the LHS values aren't sorted
-    highlights = make_highlights(
+    highlights = make_usings(
         sort_by, selection(step.axis, other=True), anchor="rhs"
     )
-    outlines = make_outlines(sorted_labels, selection(step.axis))
+    outlines = make_maps(sorted_labels, selection(step.axis))
     return [*highlights, *outlines]
 
 
@@ -144,8 +148,8 @@ def mark_for_drop(
 
     # cross out dropped rows or columns
     return [
-        *make_crossouts(col_labels, "column"),
-        *make_crossouts(row_labels, "row"),
+        *make_drops(col_labels, "column"),
+        *make_drops(row_labels, "row"),
     ]
 
 
@@ -187,7 +191,7 @@ def mark_for_apply(
     if isinstance(before, DFResult) and isinstance(after, DFResult):
         df = after.val
         labels = df.index if step.axis == "index" else df.columns
-        return make_outlines(labels, selection(step.axis))
+        return make_maps(labels, selection(step.axis))
     elif isinstance(before, DFResult) and isinstance(after, SeriesResult):
         # dogs.apply(len)  -> series with column names as index
         # special case: result is transposed! but i think this is confusing to
@@ -196,7 +200,7 @@ def mark_for_apply(
         return []
     elif isinstance(before, SeriesResult) and isinstance(after, SeriesResult):
         labels = after.val.index
-        return make_outlines(labels, "row")
+        return make_maps(labels, "row")
     else:
         # TODO: handle apply on groupby objects
         return []
@@ -207,7 +211,7 @@ def mark_for_apply(
 def mark_for_assign(
     step: AssignCall, before: EvalResult, after: EvalResult
 ) -> List[Mark]:
-    return make_highlights(step.new_col_labels, "column", "rhs")
+    return make_usings(step.new_col_labels, "column", "rhs")
 
 
 # df.groupby('hello')
@@ -226,7 +230,7 @@ def mark_for_groupby(
         for label in util.grouping_labels(after.val)
         if label in df.columns
     ]
-    highlights = make_highlights(
+    highlights = make_usings(
         group_cols, selection(step.axis, other=True), anchor="lhs"
     )
 
@@ -341,13 +345,8 @@ def mark_for_unstack(
         (CellPos("lhs", old_row, old_col), CellPos("rhs", new_row, new_col))
         for (old_row, old_col), (new_row, new_col) in cells
     ]
-    pairs = sorted(pairs, key=by_column)
-
     # group together marks that map the same column
-    cell_sets = [
-        MapSet([Map(from_, to) for from_, to in g])
-        for _, g in itertools.groupby(pairs, key=by_column)
-    ]
+    cell_sets = make_cell_sets(pairs, key=by_column)
 
     return [*index_marks, *cell_sets]
 
@@ -389,13 +388,8 @@ def mark_for_stack(
         )
         for (old_col, old_row), (new_col, new_row) in cells
     ]
-    pairs = sorted(pairs, key=by_row)
-
     # group together marks that map the same row
-    cell_sets = [
-        MapSet([Map(from_, to) for from_, to in g])
-        for _, g in itertools.groupby(pairs, key=by_row)
-    ]
+    cell_sets = make_cell_sets(pairs, key=by_row)
 
     return [*index_marks, *cell_sets]
 
@@ -414,10 +408,10 @@ def mark_for_pivot(
 
     has_index = "index" in args
     has_values = "values" in args
-    index: List[util.Label] = util.listify(args.get("index", []))
-    columns: List[util.Label] = util.listify(args.get("columns", []))
+    index: List[Label] = util.listify(args.get("index", []))
+    columns: List[Label] = util.listify(args.get("columns", []))
     # default values arg is all leftover columns
-    values: List[util.Label] = util.listify(
+    values: List[Label] = util.listify(
         args.get("values", df.columns.drop([*index, *columns]))
     )
     no_value_cols = len(values) == 0
@@ -451,9 +445,9 @@ def mark_for_pivot(
     # rows themselves so the logic is tricky
     pairs = []
     for old_row, row in df.iterrows():
-        old_row = cast(util.Label, old_row)
+        old_row = cast(Label, old_row)
         # pull new row labels from row data
-        new_row = cast(util.Label, tuple(row[index]) if has_index else old_row)
+        new_row = cast(Label, tuple(row[index]) if has_index else old_row)
 
         # pull new col labels from row data
         appended = tuple(row[columns])
@@ -464,11 +458,118 @@ def mark_for_pivot(
             pairs.append((left, right))
 
     # group together marks using their original columns
-    pairs = sorted(pairs, key=by_column)
-    cell_sets = [
-        MapSet([Map(from_, to) for from_, to in g])
-        for _, g in itertools.groupby(pairs, key=by_column)
+    cell_sets = make_cell_sets(pairs, key=by_column)
+
+    return [*index_marks, *column_marks, *cell_sets]
+
+
+# df.pivot(index='foo', columns='bar', values='baz')
+def mark_for_pivot_table(
+    step: PivotCall, before: EvalResult, after: EvalResult
+) -> List[Mark]:
+    # if index=[], pandas does the weird transpose + stack thing into a series
+    # which we won't try to handle
+    if not (isinstance(before, DFResult) and isinstance(after, DFResult)):
+        return []
+
+    df = before.val
+    after_df = after.val
+    args = after.args
+
+    has_index = "index" in args
+    has_columns = "columns" in args
+    has_values = "values" in args
+    index: List[Label] = util.listify(args.get("index", []))
+    columns: List[Label] = util.listify(args.get("columns", []))
+    # default values arg is all leftover columns
+    values: List[Label] = util.listify(
+        args.get("values", df.columns.drop([*index, *columns]))
+    )
+    aggfunc: Union[str, Callable, list, dict] = args.get("aggfunc", "mean")
+
+    # when multiple aggfuncs are specified, pandas puts the aggfuncs into
+    # another level of the column index.
+    has_multi_aggs = isinstance(aggfunc, (list, tuple)) or (
+        isinstance(aggfunc, dict)
+        and any(isinstance(val, (list, tuple)) for val in aggfunc.values())
+    )
+
+    # special case: when only one values column is specified, pandas
+    # doesn't keep it as a column. we need has_values since pandas only drops
+    # when values is explicitly passed in.
+    will_drop_values = has_values and len(values) == 1
+    no_value_cols = len(values) == 0
+    n_orig_col_levels = len(df.columns.names) if not will_drop_values else 0
+
+    # each index arg goes into a new index level
+    index_marks: List[Mark] = [
+        Map(lhs("column", name), rhs_index("row", position))
+        for position, name in enumerate(index)
     ]
+    # also highlight index columns since we're using them to group
+    index_marks += make_usings(index, "column")
+
+    # special case: result is empty dataframe with new index
+    if no_value_cols:
+        return [*index_marks]
+
+    # each column arg is appended as an index level into the columns
+    column_marks: List[Mark] = [
+        Map(
+            lhs("column", name),
+            rhs_index("column", position + n_orig_col_levels),
+        )
+        for position, name in enumerate(columns)
+    ]
+    # also highlight columns since we're using them to group
+    column_marks += make_usings(columns, "column")
+
+    # don't handle cases with multiple agg funcs since the logic is complicated
+    if has_multi_aggs:
+        return [*index_marks, *column_marks]
+
+    # internally, pandas uses a groupby + unstack to pivot so we'll follow
+    # similar logic
+    keys = [
+        label
+        for label in index + columns
+        if isinstance(label, str) and label in df.columns
+    ]
+    column_levels = list(range(len(index), len(keys)))
+    groups = util.get_groups(df.groupby(keys))
+
+    def unstack_group(labels, old_col) -> LabelPair:
+        return (
+            util.push_level(
+                labels,
+                old_col if not will_drop_values else SERIES,
+                column_levels,
+            )
+            if has_index
+            # if no index arg, there's only the column arg. pandas groups using
+            # the column arg, then *transposes* the result.
+            else (old_col, labels)
+        )
+
+    label_pairs: List[Tuple[LabelPair, LabelPair]] = [
+        ((old_row, old_col), unstack_group(labels, old_col))
+        for labels, old_rows in groups.items()
+        for old_row in old_rows
+        for old_col in values
+    ]
+    # take out cells that didn't get agg'd
+    pairs = [
+        (CellPos("lhs", old_row, old_col), CellPos("rhs", new_row, new_col))
+        for ((old_row, old_col), (new_row, new_col)) in label_pairs
+        if new_col in after_df and new_row in after_df.index
+    ]
+
+    # mapset for pivot_table() is more granular than pivot() since we want
+    # to show each individual aggregation
+    cell_sets = make_cell_sets(pairs, key=by_result_cell)
+
+    util.print_mapsets(cell_sets)
+    breakpoint()
 
     return [*index_marks, *column_marks, *cell_sets]
 
@@ -541,7 +642,7 @@ def make_subscript_comparison_marks(
     filter.
     """
     return (
-        make_highlights(labels, selection)
+        make_usings(labels, selection)
         if isinstance(subs_el, SubsComparison)
         else []
     )
@@ -646,7 +747,7 @@ def diff_rows(df1: util.HasIndex, df2: util.HasIndex, only_if_diff=True):
     special highlights.
     """
     row_matches = util.match_rows(df1, df2, only_if_diff)
-    return make_outlines(row_matches, "row")
+    return make_maps(row_matches, "row")
 
 
 def diff_cols(df1: pd.DataFrame, df2: pd.DataFrame, only_if_diff=True):
@@ -655,7 +756,7 @@ def diff_cols(df1: pd.DataFrame, df2: pd.DataFrame, only_if_diff=True):
     special highlights.
     """
     col_matches = util.match_cols(df1, df2, only_if_diff)
-    return make_outlines(col_matches, "column")
+    return make_maps(col_matches, "column")
 
 
 def no_marks(*args) -> List[Mark]:
@@ -669,7 +770,7 @@ def selection(axis: Axis, other=False) -> Selection:
     return "row" if axis == "index" else "column"
 
 
-def make_highlights(
+def make_usings(
     labels: Iterable, select: Selection, anchor: Anchor = "lhs"
 ) -> List[Mark]:
     """
@@ -678,7 +779,7 @@ def make_highlights(
     return [Using(AxisPos(anchor, select, label)) for label in labels]
 
 
-def make_outlines(labels: Iterable, select: Selection) -> List[Mark]:
+def make_maps(labels: Iterable, select: Selection) -> List[Mark]:
     """
     shorthand when index values don't change, which is most of the time
     """
@@ -687,19 +788,19 @@ def make_outlines(labels: Iterable, select: Selection) -> List[Mark]:
     ]
 
 
-def make_crossouts(labels: Iterable, select: Selection) -> List[Mark]:
+def make_drops(labels: Iterable, select: Selection) -> List[Mark]:
     """
     shorthand for crossouts
     """
     return [Drop(pos=lhs(select, label)) for label in labels]
 
 
-def lhs(select: Selection, label: util.Label) -> AxisPos:
+def lhs(select: Selection, label: Label) -> AxisPos:
     """shorthand for a column/row in lhs"""
     return AxisPos("lhs", select, label)
 
 
-def rhs(select: Selection, label: util.Label) -> AxisPos:
+def rhs(select: Selection, label: Label) -> AxisPos:
     """shorthand for a column/row in rhs"""
     return AxisPos("rhs", select, label)
 
@@ -724,13 +825,30 @@ def rhs_series() -> SeriesPos:
     return SeriesPos("rhs")
 
 
-def by_row(pair: Tuple[CellPos, CellPos]) -> util.Label:
+def by_row(pair: Tuple[CellPos, CellPos]) -> Label:
     """grouper for CellPos pairs. returns the row label of the original cell"""
     cell, _ = pair
     return cell.row
 
 
-def by_column(pair: Tuple[CellPos, CellPos]) -> util.Label:
+def by_column(pair: Tuple[CellPos, CellPos]) -> Label:
     """grouper for CellPos pairs. returns the col label of the original cell"""
     cell, _ = pair
     return cell.column
+
+
+def by_result_cell(pair: Tuple[CellPos, CellPos]) -> LabelPair:
+    """grouper for CellPos pairs. returns the row, col pair for resulting cell"""
+    _, cell = pair
+    return cell.row, cell.column
+
+
+def make_cell_sets(
+    pairs: List[Tuple[CellPos, CellPos]], key: Callable
+) -> List[MapSet]:
+    """groups pairs by key, then makes a map set for each group"""
+    pairs = sorted(pairs, key=key)
+    return [
+        MapSet([Map(from_, to) for from_, to in g])
+        for _, g in itertools.groupby(pairs, key=key)
+    ]

--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -465,7 +465,7 @@ def mark_for_pivot(
 
 # df.pivot(index='foo', columns='bar', values='baz')
 def mark_for_pivot_table(
-    step: PivotCall, before: EvalResult, after: EvalResult
+    step: PivotTableCall, before: EvalResult, after: EvalResult
 ) -> List[Mark]:
     # if index=[], pandas does the weird transpose + stack thing into a series
     # which we won't try to handle

--- a/pandas_tutor/parse.py
+++ b/pandas_tutor/parse.py
@@ -38,6 +38,7 @@ from .parse_nodes import (
     ParseSyntaxError,
     PassThroughCall,
     PivotCall,
+    PivotTableCall,
     RawCode,
     RenameCall,
     ResetIndexCall,
@@ -131,6 +132,7 @@ is_reset_index = fn_matcher("reset_index")
 is_unstack = fn_matcher("unstack")
 is_stack = fn_matcher("stack")
 is_pivot = fn_matcher("pivot")
+is_pivot_table = fn_matcher("pivot_table")
 
 # make sure to update this whenever we add a new call to the section above
 is_parsed_call = (
@@ -145,6 +147,7 @@ is_parsed_call = (
     | is_unstack
     | is_stack
     | is_pivot
+    | is_pivot_table
 )
 
 is_loc_iloc = m.Subscript(
@@ -498,6 +501,23 @@ class ChainParser(ParserBase):
             index_expr=index_expr,
             columns_expr=columns_expr,
             values_expr=values_expr,
+        )
+        self._append(node)
+
+    @m.leave(is_pivot_table)
+    def make_pivot_table(self, cst_node: cst.Call):
+        values_expr = self.get_arg_code(cst_node.args, 0, "values")
+        index_expr = self.get_arg_code(cst_node.args, 1, "index")
+        columns_expr = self.get_arg_code(cst_node.args, 2, "columns")
+        aggfunc_expr = self.get_arg_code(cst_node.args, 3, "aggfunc")
+
+        node = self.make_call_node(
+            PivotTableCall,
+            cst_node,
+            index_expr=index_expr,
+            columns_expr=columns_expr,
+            values_expr=values_expr,
+            aggfunc_expr=aggfunc_expr,
         )
         self._append(node)
 

--- a/pandas_tutor/parse_nodes.py
+++ b/pandas_tutor/parse_nodes.py
@@ -295,11 +295,29 @@ class PivotCall(Call):
     df.pivot(index='foo', columns='bar', values='baz')
     """
 
-    fn_name = "stack"
+    fn_name = "pivot"
 
     index_expr: t.Optional[RawCode] = evals_into("index")
     columns_expr: t.Optional[RawCode] = evals_into("columns")
     values_expr: t.Optional[RawCode] = evals_into("values")
+
+
+@dataclasses.dataclass
+class PivotTableCall(Call):
+    """
+    df.pivot_table(values='D', index=['A', 'B'],
+                   columns=['C'], aggfunc=np.sum)
+    df.pivot_table(values=['D', 'E'], index=['A', 'C'],
+                   aggfunc={'D': np.mean,
+                            'E': np.mean})
+    """
+
+    fn_name = "pivot_table"
+
+    index_expr: t.Optional[RawCode] = evals_into("index")
+    columns_expr: t.Optional[RawCode] = evals_into("columns")
+    values_expr: t.Optional[RawCode] = evals_into("values")
+    aggfunc_expr: t.Optional[RawCode] = evals_into("aggfunc")
 
 
 ##############################################################################

--- a/pandas_tutor/tests/e2e_golden/ptable_basic_01.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_basic_01.py
@@ -1,0 +1,21 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# simple case: each index is single level, only D values in table
+df.pivot_table(index="A", columns="C", values="D")

--- a/pandas_tutor/tests/e2e_golden/ptable_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_basic_01.py.golden
@@ -1,0 +1,353 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# simple case: each index is single level, only D values in table\ndf.pivot_table(index=\"A\", columns=\"C\", values=\"D\")\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(index=\"A\", columns=\"C\", values=\"D\")",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 50
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": "large"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": "small"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": "large"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": "small"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "C"
+            ],
+            "labels": [
+              "large",
+              "small"
+            ]
+          },
+          "index": {
+            "names": [
+              "A"
+            ],
+            "labels": [
+              "bar",
+              "foo"
+            ]
+          },
+          "data": [
+            [
+              5.5,
+              5.5
+            ],
+            [
+              2.0,
+              2.3333333333333335
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py
@@ -1,0 +1,21 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# D and E kept in columns, and C values become second column level
+df.pivot_table(index="A", columns="C")

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py.golden
@@ -1,0 +1,581 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# D and E kept in columns, and C values become second column level\ndf.pivot_table(index=\"A\", columns=\"C\")\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(index=\"A\", columns=\"C\")",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 38
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "D",
+                  "large"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "D",
+                  "large"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "D",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "D",
+                  "small"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "E",
+                  "large"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "E",
+                  "large"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "E",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "bar",
+                "column": [
+                  "E",
+                  "small"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "D",
+                  "large"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "D",
+                  "large"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "D",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "D",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "D",
+                  "small"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "E",
+                  "large"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "E",
+                  "large"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "E",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "E",
+                  "small"
+                ]
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "foo",
+                "column": [
+                  "E",
+                  "small"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              "C"
+            ],
+            "labels": [
+              [
+                "D",
+                "large"
+              ],
+              [
+                "D",
+                "small"
+              ],
+              [
+                "E",
+                "large"
+              ],
+              [
+                "E",
+                "small"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              "A"
+            ],
+            "labels": [
+              "bar",
+              "foo"
+            ]
+          },
+          "data": [
+            [
+              5.5,
+              5.5,
+              7.5,
+              8.5
+            ],
+            [
+              2.0,
+              2.3333333333333335,
+              4.5,
+              4.333333333333333
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py
@@ -1,0 +1,21 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# D and E aggregated; implied by groupby-agg with mean
+df.pivot_table(index="C")

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py.golden
@@ -1,0 +1,464 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# D and E aggregated; implied by groupby-agg with mean\ndf.pivot_table(index=\"C\")\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(index=\"C\")",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 25
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              "C"
+            ],
+            "labels": [
+              "large",
+              "small"
+            ]
+          },
+          "data": [
+            [
+              3.75,
+              6.0
+            ],
+            [
+              3.6,
+              6.0
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py
@@ -1,0 +1,21 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# A, B, D, and E aggregated; implied by groupby-agg with first
+df.pivot_table(index="C", aggfunc="first")

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py.golden
@@ -1,0 +1,760 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# A, B, D, and E aggregated; implied by groupby-agg with first\ndf.pivot_table(index=\"C\", aggfunc=\"first\")\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(index=\"C\", aggfunc=\"first\")",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 42
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "A"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "B"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "large",
+                "column": "E"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "A"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "A"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "A"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "B"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "B"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "B"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "small",
+                "column": "E"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              "C"
+            ],
+            "labels": [
+              "large",
+              "small"
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              1,
+              2
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py
@@ -1,0 +1,24 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import numpy as np
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# different aggfuncs per column
+df.pivot_table(values=['D', 'E'], index=['A', 'C'],
+               aggfunc={'D': np.mean,
+                        'E': np.max})

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py.golden
@@ -1,0 +1,585 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport numpy as np\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# different aggfuncs per column\ndf.pivot_table(values=['D', 'E'], index=['A', 'C'],\n               aggfunc={'D': np.mean,\n                        'E': np.max})\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(values=['D', 'E'], index=['A', 'C'],\n               aggfunc={'D': np.mean,\n                        'E': np.max})",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 2,
+          "ch": 37
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "large"
+                ],
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "large"
+                ],
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "large"
+                ],
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "large"
+                ],
+                "column": "E"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "small"
+                ],
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "small"
+                ],
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "small"
+                ],
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "bar",
+                  "small"
+                ],
+                "column": "E"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "large"
+                ],
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "large"
+                ],
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "large"
+                ],
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "large"
+                ],
+                "column": "E"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "D"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "D"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "E"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": [
+                  "foo",
+                  "small"
+                ],
+                "column": "E"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              "A",
+              "C"
+            ],
+            "labels": [
+              [
+                "bar",
+                "large"
+              ],
+              [
+                "bar",
+                "small"
+              ],
+              [
+                "foo",
+                "large"
+              ],
+              [
+                "foo",
+                "small"
+              ]
+            ]
+          },
+          "data": [
+            [
+              5.5,
+              9.0
+            ],
+            [
+              5.5,
+              9.0
+            ],
+            [
+              2.0,
+              5.0
+            ],
+            [
+              2.3333333333333335,
+              6.0
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py
@@ -1,0 +1,26 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import numpy as np
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# multi-agg, unsupported
+df.pivot_table(
+    values=["D", "E"],
+    index=["A", "C"],
+    aggfunc={"D": np.mean, "E": [min, max, np.mean]},
+)

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py.golden
@@ -1,0 +1,244 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport numpy as np\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# multi-agg, unsupported\ndf.pivot_table(\n    values=[\"D\", \"E\"],\n    index=[\"A\", \"C\"],\n    aggfunc={\"D\": np.mean, \"E\": [min, max, np.mean]},\n)\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(\n    values=[\"D\", \"E\"],\n    index=[\"A\", \"C\"],\n    aggfunc={\"D\": np.mean, \"E\": [min, max, np.mean]},\n)",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 4,
+          "ch": 1
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null,
+              null
+            ],
+            "labels": [
+              [
+                "D",
+                "mean"
+              ],
+              [
+                "E",
+                "max"
+              ],
+              [
+                "E",
+                "mean"
+              ],
+              [
+                "E",
+                "min"
+              ]
+            ]
+          },
+          "index": {
+            "names": [
+              "A",
+              "C"
+            ],
+            "labels": [
+              [
+                "bar",
+                "large"
+              ],
+              [
+                "bar",
+                "small"
+              ],
+              [
+                "foo",
+                "large"
+              ],
+              [
+                "foo",
+                "small"
+              ]
+            ]
+          },
+          "data": [
+            [
+              5.5,
+              9.0,
+              7.5,
+              6.0
+            ],
+            [
+              5.5,
+              9.0,
+              8.5,
+              8.0
+            ],
+            [
+              2.0,
+              5.0,
+              4.5,
+              4.0
+            ],
+            [
+              2.3333333333333335,
+              6.0,
+              4.333333333333333,
+              2.0
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py
+++ b/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py
@@ -1,0 +1,21 @@
+# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects
+import pandas as pd
+import io
+
+csv = """
+A,B,C,D,E
+foo,one,small,1,2
+foo,one,large,2,4
+foo,one,large,2,5
+foo,two,small,3,5
+foo,two,small,3,6
+bar,one,large,4,6
+bar,one,small,5,8
+bar,two,small,6,9
+bar,two,large,7,9
+"""
+
+df = pd.read_csv(io.StringIO(csv))
+
+# when only columns are passed, D and E get aggregated and transposed into rows
+df.pivot_table(columns="C")

--- a/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py.golden
@@ -1,0 +1,464 @@
+{
+  "code": "# https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html#reshaping-by-pivoting-dataframe-objects\nimport pandas as pd\nimport io\n\ncsv = \"\"\"\nA,B,C,D,E\nfoo,one,small,1,2\nfoo,one,large,2,4\nfoo,one,large,2,5\nfoo,two,small,3,5\nfoo,two,small,3,6\nbar,one,large,4,6\nbar,one,small,5,8\nbar,two,small,6,9\nbar,two,large,7,9\n\"\"\"\n\ndf = pd.read_csv(io.StringIO(csv))\n\n# when only columns are passed, D and E get aggregated and transposed into rows\ndf.pivot_table(columns=\"C\")\n",
+  "explanation": [
+    {
+      "type": "PivotTableCall",
+      "code_step": "df.pivot_table(columns=\"C\")",
+      "fragment": {
+        "start": {
+          "line": 0,
+          "ch": 2
+        },
+        "end": {
+          "line": 0,
+          "ch": 27
+        }
+      },
+      "marks": [
+        {
+          "type": "map",
+          "from": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          },
+          "to": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "large"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "D"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "D",
+                "column": "small"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 1,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 2,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 5,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "large"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 8,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "large"
+              }
+            }
+          ]
+        },
+        {
+          "type": "map_set",
+          "maps": [
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 0,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 3,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 4,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 6,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "small"
+              }
+            },
+            {
+              "type": "map",
+              "from": {
+                "type": "cell",
+                "anchor": "lhs",
+                "row": 7,
+                "column": "E"
+              },
+              "to": {
+                "type": "cell",
+                "anchor": "rhs",
+                "row": "E",
+                "column": "small"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "lhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "data": [
+            [
+              "foo",
+              "one",
+              "small",
+              1,
+              2
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              4
+            ],
+            [
+              "foo",
+              "one",
+              "large",
+              2,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              5
+            ],
+            [
+              "foo",
+              "two",
+              "small",
+              3,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "large",
+              4,
+              6
+            ],
+            [
+              "bar",
+              "one",
+              "small",
+              5,
+              8
+            ],
+            [
+              "bar",
+              "two",
+              "small",
+              6,
+              9
+            ],
+            [
+              "bar",
+              "two",
+              "large",
+              7,
+              9
+            ]
+          ]
+        },
+        "rhs": {
+          "type": "DataFrame",
+          "columns": {
+            "names": [
+              "C"
+            ],
+            "labels": [
+              "large",
+              "small"
+            ]
+          },
+          "index": {
+            "names": [
+              null
+            ],
+            "labels": [
+              "D",
+              "E"
+            ]
+          },
+          "data": [
+            [
+              3.75,
+              3.6
+            ],
+            [
+              6.0,
+              6.0
+            ]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pandas_tutor/util.py
+++ b/pandas_tutor/util.py
@@ -10,6 +10,7 @@ import itertools
 import warnings
 from collections.abc import Iterable, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -27,6 +28,9 @@ import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy, SeriesGroupBy
 from pandas.core.groupby.groupby import GroupBy
 from typing_extensions import TypeGuard
+
+if TYPE_CHECKING:
+    from pandas_tutor.diagram import MapSet, CellPos
 
 T = TypeVar("T")
 
@@ -322,6 +326,16 @@ def push_levels(
     return zip(orig, new)
 
 
+def push_level(from_: Label, to: Label, levels: List[int]) -> LabelPair:
+    """pushes levels from_ -> to for one label pair"""
+    # if we're pushing into a series, we need to handle the placeholder
+    to = to if to != SERIES else tuple()
+    left = tuplify(from_)
+    right = tuplify(to)
+    move, stay = split_by(left, levels)
+    return mapt(unwrap, (stay, (*right, *move)))
+
+
 @overload
 def ungroup(obj: Union[SeriesGroupBy, pd.Series]) -> pd.Series:
     ...
@@ -463,3 +477,23 @@ def too_much_mem_msg(mem: float):
         f"Your total data uses {mem_as_str(mem)} of memory, which exceeds "
         f"the maximum of {mem_as_str(MEM_LIMIT)} that this tool supports."
     )
+
+
+##############################################################################
+# debugging
+##############################################################################
+
+
+def print_mapsets(val: List[MapSet]) -> None:
+    for i, mapset in enumerate(val):
+        print(f"{i}:")
+        for map_mark in mapset.maps:
+            left = (
+                f"{str(map_mark.from_.row)}, "  # type: ignore
+                f"{str(map_mark.from_.column)}"  # type: ignore
+            )
+            right = (
+                f"{str(map_mark.to.row)}, "  # type: ignore
+                f"{str(map_mark.to.column)}"  # type: ignore
+            )
+            print(f"  {left} -> {right}")


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/88

adds support for pivot_table() calls. these are similar to pivot(), but support aggregation.

i make a MapSet for each aggregated cell of the final dataframe.

https://github.com/SamLau95/pandas_tutor/blob/eee397f6b6dadaec7539da399a1a38ca5b225517/pandas_tutor/tests/e2e_golden/ptable_basic_01.py#L20-L21

https://github.com/SamLau95/pandas_tutor/blob/eee397f6b6dadaec7539da399a1a38ca5b225517/pandas_tutor/tests/e2e_golden/ptable_basic_01.py.golden#L18-L221