### PR TITLE
add using marks for reshape operations

### DIFF
--- a/pandas_tutor/marks.py
+++ b/pandas_tutor/marks.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -29,6 +30,7 @@ from .diagram import (
     PosPair,
     Selection,
     SeriesPos,
+    TablePos,
     Using,
 )
 from .parse_nodes import (
@@ -347,12 +349,13 @@ def mark_for_unstack(
     n_orig_levels = len(columns.names) if util.is_dataframe(df) else 0
 
     index_marks: List[Mark] = [
-        Map(
+        mark
+        for index_level, level in enumerate(levels)
+        for mark in using_and_map(
             lhs_index("row", level),
             # unstacking puts the new levels **under** the existing ones
             rhs_index("column", index_level + n_orig_levels),
         )
-        for index_level, level in enumerate(levels)
     ]
 
     # for each cell: the unstacked labels move to the column index
@@ -383,15 +386,16 @@ def mark_for_stack(
     levels = util.listify(args.get("level", len(df.columns.names) - 1))
     levels = [util.level_number(df.columns, level) for level in levels]
 
-    # stacking puts the new levels **after** the existing ones
     n_index_levels = len(df.index.names)
 
     index_marks: List[Mark] = [
-        Map(
+        mark
+        for index_level, level in enumerate(levels)
+        for mark in using_and_map(
             IndexLevelPos("lhs", "column", level),
+            # stacking puts the new levels **after** the existing ones
             IndexLevelPos("rhs", "row", index_level + n_index_levels),
         )
-        for index_level, level in enumerate(levels)
     ]
 
     # for each cell: the unstacked labels move to the row index
@@ -438,10 +442,12 @@ def mark_for_pivot(
     will_drop_values = has_values and len(values) == 1
     n_orig_col_levels = len(df.columns.names) if not will_drop_values else 0
 
-    # each index arg goes into a new index level
     index_marks = [
-        Map(lhs("column", name), rhs_index("row", position))
+        mark
         for position, name in enumerate(index)
+        for mark in using_and_map(
+            lhs("column", name), rhs_index("row", position)
+        )
     ]
 
     # special case: result is empty dataframe with new index
@@ -518,12 +524,13 @@ def mark_for_pivot_table(
     n_orig_col_levels = len(df.columns.names) if not will_drop_values else 0
 
     # each index arg goes into a new index level
-    index_marks: List[Mark] = [
-        Map(lhs("column", name), rhs_index("row", position))
+    index_marks = [
+        mark
         for position, name in enumerate(index)
+        for mark in using_and_map(
+            lhs("column", name), rhs_index("row", position)
+        )
     ]
-    # also highlight index columns since we're using them to group
-    index_marks += make_usings(index, "column")
 
     # special case: result is empty dataframe with new index
     if no_value_cols:
@@ -531,14 +538,13 @@ def mark_for_pivot_table(
 
     # each column arg is appended as an index level into the columns
     column_marks: List[Mark] = [
-        Map(
+        mark
+        for position, name in enumerate(columns)
+        for mark in using_and_map(
             lhs("column", name),
             rhs_index("column", position + n_orig_col_levels),
         )
-        for position, name in enumerate(columns)
     ]
-    # also highlight columns since we're using them to group
-    column_marks += make_usings(columns, "column")
 
     # don't handle cases with multiple agg funcs since the logic is complicated
     if has_multi_aggs:
@@ -993,6 +999,11 @@ def make_drops(
     shorthand for crossouts
     """
     return [Drop(AxisPos(anchor, select, label)) for label in labels]
+
+
+def using_and_map(left_pos: TablePos, right_pos: TablePos) -> List[Mark]:
+    """Map left to right and Using both"""
+    return [Using(left_pos), Using(right_pos), Map(left_pos, right_pos)]
 
 
 def lhs(select: Selection, label: Label) -> AxisPos:

--- a/pandas_tutor/tests/e2e_golden/pivot_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_basic_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",

--- a/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_empty_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "zoo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -28,6 +46,24 @@
             "anchor": "rhs",
             "select": "row",
             "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_indexes_02.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "zoo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -28,6 +46,24 @@
             "anchor": "rhs",
             "select": "row",
             "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/pivot_without_values_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "foo"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",

--- a/pandas_tutor/tests/e2e_golden/ptable_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_basic_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -36,7 +54,16 @@
             "type": "axis",
             "anchor": "lhs",
             "select": "column",
-            "label": "A"
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
           }
         },
         {
@@ -52,15 +79,6 @@
             "anchor": "rhs",
             "select": "column",
             "level": 0
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -36,7 +54,16 @@
             "type": "axis",
             "anchor": "lhs",
             "select": "column",
-            "label": "A"
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
           }
         },
         {
@@ -52,15 +79,6 @@
             "anchor": "rhs",
             "select": "column",
             "level": 1
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_02.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -28,15 +46,6 @@
             "anchor": "rhs",
             "select": "row",
             "level": 0
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_implied_values_03.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -28,15 +46,6 @@
             "anchor": "rhs",
             "select": "row",
             "level": 0
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -31,6 +49,24 @@
           }
         },
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -43,24 +79,6 @@
             "anchor": "rhs",
             "select": "row",
             "level": 1
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "A"
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_multi_agg_complex_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "A"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -31,6 +49,24 @@
           }
         },
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -43,24 +79,6 @@
             "anchor": "rhs",
             "select": "row",
             "level": 1
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "A"
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         }
       ],

--- a/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/ptable_only_columns_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "axis",
+            "anchor": "lhs",
+            "select": "column",
+            "label": "C"
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "axis",
@@ -28,15 +46,6 @@
             "anchor": "rhs",
             "select": "column",
             "level": 0
-          }
-        },
-        {
-          "type": "using",
-          "pos": {
-            "type": "axis",
-            "anchor": "lhs",
-            "select": "column",
-            "label": "C"
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",

--- a/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_basic_02.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",

--- a/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_into_unstack_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 2
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",
@@ -441,6 +459,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 3
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",
@@ -830,6 +866,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 3
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",
@@ -1179,6 +1233,24 @@
         }
       },
       "marks": [
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 2
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        },
         {
           "type": "map",
           "from": {
@@ -1534,6 +1606,24 @@
         }
       },
       "marks": [
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 2
+          }
+        },
         {
           "type": "map",
           "from": {

--- a/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/stack_multi_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",
@@ -28,6 +46,24 @@
             "anchor": "rhs",
             "select": "row",
             "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "row",
+            "level": 2
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",

--- a/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_multiple.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 1
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",
@@ -28,6 +46,24 @@
             "anchor": "rhs",
             "select": "column",
             "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 2
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 2
           }
         },
         {

--- a/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_01.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 1
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",

--- a/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
+++ b/pandas_tutor/tests/e2e_golden/unstack_series_02.py.golden
@@ -16,6 +16,24 @@
       },
       "marks": [
         {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "lhs",
+            "select": "row",
+            "level": 0
+          }
+        },
+        {
+          "type": "using",
+          "pos": {
+            "type": "index_level",
+            "anchor": "rhs",
+            "select": "column",
+            "level": 0
+          }
+        },
+        {
           "type": "map",
           "from": {
             "type": "index_level",


### PR DESCRIPTION
closes https://github.com/SamLau95/pandas_tutor/issues/133

stack(), unstack(), pivot(), and pivot_table() calls now have Using marks for both LHS and RHS tables to show which index levels we used for reshaping.